### PR TITLE
fix: add proper imports for Properties and FileInputStream

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,14 +5,17 @@ plugins {
     id("com.google.devtools.ksp")
 }
 
+import java.util.Properties
+import java.io.FileInputStream
+
 // Support version name override from CI (e.g., for PR builds)
 val versionNameOverride: String? by project
 
 // Load keystore properties for signing
 val keystorePropertiesFile = rootProject.file("keystore.properties")
-val keystoreProperties = java.util.Properties()
+val keystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(java.io.FileInputStream(keystorePropertiesFile))
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {


### PR DESCRIPTION
Fixes build script compilation errors in build.gradle.kts

## Changes
- Added explicit imports for java.util.Properties and java.io.FileInputStream
- Fixed unresolved reference errors in signing configuration

## Testing
- Local build should succeed with signing configured
- CI/CD will verify signed APK generation