### PR TITLE
chore(deps): Phase 3 - Hilt Navigation update (requires PR #23)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,9 +121,9 @@ dependencies {
     implementation("androidx.exifinterface:exifinterface:1.3.7")
 
     // Hilt (Dependency Injection)
-    implementation("com.google.dagger:hilt-android:2.48.1")
-    ksp("com.google.dagger:hilt-android-compiler:2.48.1")
-    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
+    implementation("com.google.dagger:hilt-android:2.58")
+    ksp("com.google.dagger:hilt-android-compiler:2.58")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
     // Room (Local Database)
     implementation("androidx.room:room-runtime:2.6.1")


### PR DESCRIPTION
## Summary
Phase 3 of dependency updates - KSP-dependent libraries (Hilt, Navigation).

## ⚠️ Dependency
**This PR requires PR #23 (Phase 2: Kotlin + KSP + AGP) to be merged first.**

## Changes

### Updated
| Dependency | From | To | Reason |
|------------|------|-----|--------|
| **Hilt Android** | 2.48.1 | 2.58 | Align with root plugin |
| **Hilt Compiler** | 2.48.1 | 2.58 | Match Hilt Android |
| **Hilt Navigation Compose** | 1.1.0 | 1.2.0 | Latest compatible |

### NOT Updated (Already Compatible)
| Dependency | Version | Status |
|------------|---------|--------|
| Room Runtime | 2.6.1 | ✅ Compatible |
| Room KTX | 2.6.1 | ✅ Compatible |
| Room Compiler (KSP) | 2.6.1 | ✅ Compatible |

## Compatibility

| Library | Version | Compatible With |
|---------|---------|-----------------|
| Hilt 2.58 | ✅ | Kotlin 1.9.25, AGP 8.4.0 |
| Hilt Navigation 1.2.0 | ✅ | Hilt 2.58 |
| Room 2.6.1 | ✅ | Kotlin 1.9.25, KSP 1.9.25 |

## Testing (After Phase 2 Merge)
- [ ] Build passes: `./gradlew clean build`
- [ ] Tests pass: `./gradlew test`
- [ ] APK builds: `./gradlew assembleDebug`
- [ ] Hilt dependency injection works
- [ ] Navigation with @HiltViewModel works

## Next Steps (Phase 4)
After this merges:
1. AGP 8.4.0 → 8.7.0 (optional, for latest features)
2. Media3 1.2.1 → 1.9.2 (if needed)

## References
- Hilt 2.58 release notes: https://github.com/google/dagger/releases
- Hilt Navigation Compose: https://developer.android.com/jetpack/compose/libraries#hilt