### PR TITLE
ci: Optimize workflows to avoid duplicate APK builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -23,61 +23,11 @@ jobs:
 
   build-release:
     name: Build Release APK
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/reusable-build-apk.yml
     with:
       build-type: release
       version-name: ${{ github.event_name == 'pull_request' && format('pr{0}-{1}', github.event.pull_request.number, github.sha) || github.sha }}
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up JDK 17
-      uses: actions/setup-java@v5
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: gradle
-
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-
-    - name: Run lint
-      run: ./gradlew lint --no-daemon
-
-    - name: Upload lint reports
-      uses: actions/upload-artifact@v7
-      if: always()
-      with:
-        name: lint-reports-${{ github.run_id }}
-        path: app/build/reports/lint/
-        if-no-files-found: ignore
-
-  dependency-check:
-    name: Dependency Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up JDK 17
-      uses: actions/setup-java@v5
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-
-    - name: Check dependencies
-      run: ./gradlew dependencies --no-daemon
 
   release:
     name: Create Release
@@ -105,7 +55,7 @@ jobs:
 
   post-artifact-links:
     name: Post Artifact Links
-    needs: [build-debug, build-release, lint, dependency-check]
+    needs: [build-debug, build-release]
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && always()
 

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -17,25 +17,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Determine run context and get artifact info
+  check-prerequisites:
+    name: Check Prerequisites
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+      is-workflow-run: ${{ steps.check.outputs.is-workflow-run }}
+      parent-run-id: ${{ steps.check.outputs.parent-run-id }}
+    steps:
+    - name: Determine run context
+      id: check
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "should-run=true" >> $GITHUB_OUTPUT
+          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
+          echo "parent-run-id=" >> $GITHUB_OUTPUT
+        elif [ "${{ github.event.workflow_run.conclusion }}" == "success" ]; then
+          echo "should-run=true" >> $GITHUB_OUTPUT
+          echo "is-workflow-run=true" >> $GITHUB_OUTPUT
+          echo "parent-run-id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+        else
+          echo "should-run=false" >> $GITHUB_OUTPUT
+          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
+          echo "parent-run-id=" >> $GITHUB_OUTPUT
+        fi
+
+  # Download artifacts from parent workflow if triggered by workflow_run
+  download-artifacts:
+    name: Download Artifacts
+    runs-on: ubuntu-latest
+    needs: [check-prerequisites]
+    if: needs.check-prerequisites.outputs.is-workflow-run == 'true'
+    steps:
+    - name: Download debug APK
+      uses: actions/download-artifact@v7
+      with:
+        pattern: app-debug-*
+        merge-multiple: true
+        github-token: ${{ github.token }}
+        run-id: ${{ needs.check-prerequisites.outputs.parent-run-id }}
+
+    - name: List downloaded files
+      run: |
+        echo "Downloaded files:"
+        ls -la app-*.apk 2>/dev/null || echo "No APK files found"
+
+    - name: Upload as reusable artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: debug-apk-for-validation
+        path: app-*.apk
+        if-no-files-found: error
+        retention-days: 1
+
+  # Validate APK - reuses build from Android CI/CD when available
   validate-apk:
     name: Validate APK
+    needs: [check-prerequisites, download-artifacts]
+    if: needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
+      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
 
+  # Test on emulator - reuses build from Android CI/CD when available
   test-on-emulator:
     name: Test on Emulator
-    needs: [validate-apk]
+    needs: [check-prerequisites, validate-apk]
+    if: needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      api-level: 29
+      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
 
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [validate-apk, test-on-emulator]
-    if: always()
+    needs: [check-prerequisites, validate-apk, test-on-emulator]
+    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
 
     steps:
     - name: Generate summary
@@ -61,6 +121,10 @@ jobs:
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
-        echo "- Validated APK: Available in workflow artifacts" >> $GITHUB_STEP_SUMMARY
-        echo "- Emulator screenshot: Available if test ran" >> $GITHUB_STEP_SUMMARY
+        echo "### Build Efficiency" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ needs.check-prerequisites.outputs.is-workflow-run }}" == "true" ]; then
+          echo "- ♻️ Reused APK from Android CI/CD workflow" >> $GITHUB_STEP_SUMMARY
+          echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- 🔨 Built APK for validation (direct PR trigger)" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -75,7 +75,7 @@ jobs:
   validate-apk:
     name: Validate APK
     needs: [check-prerequisites, download-artifacts]
-    if: needs.check-prerequisites.outputs.should-run == 'true'
+    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
@@ -85,7 +85,7 @@ jobs:
   test-on-emulator:
     name: Test on Emulator
     needs: [check-prerequisites, validate-apk]
-    if: needs.check-prerequisites.outputs.should-run == 'true'
+    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -17,6 +17,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Download artifacts from parent workflow if triggered by workflow_run
+  download-artifacts:
+    name: Download Artifacts
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download debug APK
+      uses: actions/download-artifact@v7
+      with:
+        pattern: app-debug-*
+        merge-multiple: true
+        github-token: ${{ github.token }}
+        run-id: ${{ github.event.workflow_run.id }}
+
+    - name: Upload as reusable artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: debug-apk-for-validation
+        path: app-*.apk
+        if-no-files-found: error
+        retention-days: 1
+
   # Run unit tests (always runs, independent of APK)
   unit-tests:
     name: Unit Tests
@@ -47,22 +69,25 @@ jobs:
         path: app/build/reports/tests/
         if-no-files-found: ignore
 
-  # Validate APK structure - reuses build from Android CI/CD when available
+  # Validate APK structure - builds for PR, reuses for workflow_run
   validate-apk:
     name: Validate APK
+    needs: [download-artifacts]
+    if: always()
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
       skip-build: ${{ github.event_name == 'workflow_run' }}
 
-  # Test on emulator - reuses APK from validate-apk (NO double-build)
+  # Test on emulator - builds for PR, reuses for workflow_run
   test-on-emulator:
     name: Test on Emulator
     needs: [validate-apk]
+    if: always()
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      skip-build: true
+      skip-build: ${{ github.event_name == 'workflow_run' }}
 
   summary:
     name: Test Summary

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -71,7 +71,39 @@ jobs:
         if-no-files-found: error
         retention-days: 1
 
-  # Validate APK - reuses build from Android CI/CD when available
+  # Run unit tests (always runs, independent of APK)
+  unit-tests:
+    name: Unit Tests
+    needs: [check-prerequisites]
+    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Run unit tests
+      run: ./gradlew test --no-daemon
+      timeout-minutes: 20
+
+    - name: Upload test reports
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: unit-test-reports-${{ github.run_id }}
+        path: app/build/reports/tests/
+        if-no-files-found: ignore
+
+  # Validate APK structure - reuses build from Android CI/CD when available
   validate-apk:
     name: Validate APK
     needs: [check-prerequisites, download-artifacts]
@@ -81,7 +113,7 @@ jobs:
       build-type: debug
       skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
 
-  # Test on emulator - reuses build from Android CI/CD when available
+  # Test on emulator - reuses APK from validate-apk (NO double-build)
   test-on-emulator:
     name: Test on Emulator
     needs: [check-prerequisites, validate-apk]
@@ -89,12 +121,12 @@ jobs:
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
+      skip-build: true  # Always reuse - validate-apk already built/downloaded
 
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [check-prerequisites, validate-apk, test-on-emulator]
+    needs: [check-prerequisites, unit-tests, validate-apk, test-on-emulator]
     if: always() && needs.check-prerequisites.outputs.should-run == 'true'
 
     steps:
@@ -103,6 +135,16 @@ jobs:
         echo "## Test Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
+        echo "### Unit Tests" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ needs.unit-tests.result }}" == "success" ]; then
+          echo "✓ Unit tests passed" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.unit-tests.result }}" == "failure" ]; then
+          echo "✗ Unit tests failed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "⚠️ Unit tests skipped or cancelled" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "" >> $GITHUB_STEP_SUMMARY
         echo "### APK Validation" >> $GITHUB_STEP_SUMMARY
         if [ "${{ needs.validate-apk.result }}" == "success" ]; then
           echo "✓ APK structure validated" >> $GITHUB_STEP_SUMMARY
@@ -127,4 +169,5 @@ jobs:
           echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY
         else
           echo "- 🔨 Built APK for validation (direct PR trigger)" >> $GITHUB_STEP_SUMMARY
+          echo "- ⚠️ Note: APK built once, reused for validation + emulator" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -11,7 +11,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: apk-validation-${{ github.head_ref || github.ref_name }}
+  group: apk-validation-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -1,8 +1,6 @@
 name: APK Validation Tests
 
 on:
-  pull_request:
-    branches: [ "main", "master", "develop" ]
   workflow_run:
     workflows: ["Android CI/CD"]
     types:
@@ -17,10 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Download artifacts from parent workflow if triggered by workflow_run
+  # Download artifacts from parent workflow
   download-artifacts:
     name: Download Artifacts
-    if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     steps:
     - name: Download debug APK
@@ -69,25 +66,23 @@ jobs:
         path: app/build/reports/tests/
         if-no-files-found: ignore
 
-  # Validate APK structure - builds for PR, reuses for workflow_run
+  # Validate APK structure - reuses APK from Android CI/CD
   validate-apk:
     name: Validate APK
     needs: [download-artifacts]
-    if: always()
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
-      skip-build: ${{ github.event_name == 'workflow_run' }}
+      skip-build: true
 
-  # Test on emulator - builds for PR, reuses for workflow_run
+  # Test on emulator - reuses APK from Android CI/CD
   test-on-emulator:
     name: Test on Emulator
     needs: [validate-apk]
-    if: always()
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      skip-build: ${{ github.event_name == 'workflow_run' }}
+      skip-build: true
 
   summary:
     name: Test Summary
@@ -130,10 +125,5 @@ jobs:
 
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Build Efficiency" >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.event_name }}" == "workflow_run" ]; then
-          echo "- ♻️ Reused APK from Android CI/CD workflow" >> $GITHUB_STEP_SUMMARY
-          echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "- 🔨 Built APK for validation (direct PR trigger)" >> $GITHUB_STEP_SUMMARY
-          echo "- ⚠️ Note: APK built once, reused for validation + emulator" >> $GITHUB_STEP_SUMMARY
-        fi
+        echo "- ♻️ Reused APK from Android CI/CD workflow" >> $GITHUB_STEP_SUMMARY
+        echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -17,25 +17,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Determine if we should run and get artifact info
+  check-prerequisites:
+    name: Check Prerequisites
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+      is-workflow-run: ${{ steps.check.outputs.is-workflow-run }}
+      parent-run-id: ${{ steps.check.outputs.parent-run-id }}
+    steps:
+    - name: Determine run context
+      id: check
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "should-run=true" >> $GITHUB_OUTPUT
+          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
+          echo "parent-run-id=" >> $GITHUB_OUTPUT
+        elif [ "${{ github.event.workflow_run.conclusion }}" == "success" ]; then
+          echo "should-run=true" >> $GITHUB_OUTPUT
+          echo "is-workflow-run=true" >> $GITHUB_OUTPUT
+          echo "parent-run-id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+        else
+          echo "should-run=false" >> $GITHUB_OUTPUT
+          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
+          echo "parent-run-id=" >> $GITHUB_OUTPUT
+        fi
+
+  # Download artifacts from parent workflow if triggered by workflow_run
+  download-artifacts:
+    name: Download Artifacts
+    runs-on: ubuntu-latest
+    needs: [check-prerequisites]
+    if: needs.check-prerequisites.outputs.is-workflow-run == 'true'
+    steps:
+    - name: Download debug APK
+      uses: actions/download-artifact@v7
+      with:
+        pattern: app-debug-*
+        merge-multiple: true
+        github-token: ${{ github.token }}
+        run-id: ${{ needs.check-prerequisites.outputs.parent-run-id }}
+
+    - name: List downloaded files
+      run: |
+        echo "Downloaded files:"
+        ls -la app-*.apk 2>/dev/null || echo "No APK files found"
+
+    - name: Upload as reusable artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: debug-apk-for-validation
+        path: app-*.apk
+        if-no-files-found: error
+        retention-days: 1
+
+  # Validate APK - reuses build from Android CI/CD when available
   validate-apk:
     name: Validate APK
+    needs: [check-prerequisites, download-artifacts]
+    if: needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
+      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
 
+  # Test on emulator - reuses build from Android CI/CD when available
   test-on-emulator:
     name: Test on Emulator
-    needs: [validate-apk]
+    needs: [check-prerequisites, validate-apk]
+    if: needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      api-level: 29
+      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
 
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [validate-apk, test-on-emulator]
-    if: always()
+    needs: [check-prerequisites, validate-apk, test-on-emulator]
+    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
 
     steps:
     - name: Generate summary
@@ -61,6 +121,10 @@ jobs:
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
-        echo "- Validated APK: Available in workflow artifacts" >> $GITHUB_STEP_SUMMARY
-        echo "- Emulator screenshot: Available if test ran" >> $GITHUB_STEP_SUMMARY
+        echo "### Build Efficiency" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ needs.check-prerequisites.outputs.is-workflow-run }}" == "true" ]; then
+          echo "- ♻️ Reused APK from Android CI/CD workflow" >> $GITHUB_STEP_SUMMARY
+          echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- 🔨 Built APK for validation (direct PR trigger)" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -106,7 +106,7 @@ jobs:
   # Validate APK structure - reuses build from Android CI/CD when available
   validate-apk:
     name: Validate APK
-    needs: [check-prerequisites, download-artifacts]
+    needs: [check-prerequisites]
     if: always() && needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -17,85 +17,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Determine if we should run and get artifact info
-  check-prerequisites:
-    name: Check Prerequisites
-    runs-on: ubuntu-latest
-    outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
-      is-workflow-run: ${{ steps.check.outputs.is-workflow-run }}
-      parent-run-id: ${{ steps.check.outputs.parent-run-id }}
-    steps:
-    - name: Determine run context
-      id: check
-      run: |
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "should-run=true" >> $GITHUB_OUTPUT
-          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
-          echo "parent-run-id=" >> $GITHUB_OUTPUT
-        elif [ "${{ github.event.workflow_run.conclusion }}" == "success" ]; then
-          echo "should-run=true" >> $GITHUB_OUTPUT
-          echo "is-workflow-run=true" >> $GITHUB_OUTPUT
-          echo "parent-run-id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
-        else
-          echo "should-run=false" >> $GITHUB_OUTPUT
-          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
-          echo "parent-run-id=" >> $GITHUB_OUTPUT
-        fi
-
-  # Download artifacts from parent workflow if triggered by workflow_run
-  download-artifacts:
-    name: Download Artifacts
-    runs-on: ubuntu-latest
-    needs: [check-prerequisites]
-    if: needs.check-prerequisites.outputs.is-workflow-run == 'true'
-    steps:
-    - name: Download debug APK
-      uses: actions/download-artifact@v7
-      with:
-        pattern: app-debug-*
-        merge-multiple: true
-        github-token: ${{ github.token }}
-        run-id: ${{ needs.check-prerequisites.outputs.parent-run-id }}
-
-    - name: List downloaded files
-      run: |
-        echo "Downloaded files:"
-        ls -la app-*.apk 2>/dev/null || echo "No APK files found"
-
-    - name: Upload as reusable artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: debug-apk-for-validation
-        path: app-*.apk
-        if-no-files-found: error
-        retention-days: 1
-
-  # Validate APK - reuses build from Android CI/CD when available
   validate-apk:
     name: Validate APK
-    needs: [check-prerequisites, download-artifacts]
-    if: needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
-      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
 
-  # Test on emulator - reuses build from Android CI/CD when available
   test-on-emulator:
     name: Test on Emulator
-    needs: [check-prerequisites, validate-apk]
-    if: needs.check-prerequisites.outputs.should-run == 'true'
+    needs: [validate-apk]
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
+      api-level: 29
 
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [check-prerequisites, validate-apk, test-on-emulator]
-    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
+    needs: [validate-apk, test-on-emulator]
+    if: always()
 
     steps:
     - name: Generate summary
@@ -121,10 +61,6 @@ jobs:
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Build Efficiency" >> $GITHUB_STEP_SUMMARY
-        if [ "${{ needs.check-prerequisites.outputs.is-workflow-run }}" == "true" ]; then
-          echo "- ♻️ Reused APK from Android CI/CD workflow" >> $GITHUB_STEP_SUMMARY
-          echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "- 🔨 Built APK for validation (direct PR trigger)" >> $GITHUB_STEP_SUMMARY
-        fi
+        echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
+        echo "- Validated APK: Available in workflow artifacts" >> $GITHUB_STEP_SUMMARY
+        echo "- Emulator screenshot: Available if test ran" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/apk-validation.yml
+++ b/.github/workflows/apk-validation.yml
@@ -17,65 +17,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Determine run context and get artifact info
-  check-prerequisites:
-    name: Check Prerequisites
-    runs-on: ubuntu-latest
-    outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
-      is-workflow-run: ${{ steps.check.outputs.is-workflow-run }}
-      parent-run-id: ${{ steps.check.outputs.parent-run-id }}
-    steps:
-    - name: Determine run context
-      id: check
-      run: |
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "should-run=true" >> $GITHUB_OUTPUT
-          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
-          echo "parent-run-id=" >> $GITHUB_OUTPUT
-        elif [ "${{ github.event.workflow_run.conclusion }}" == "success" ]; then
-          echo "should-run=true" >> $GITHUB_OUTPUT
-          echo "is-workflow-run=true" >> $GITHUB_OUTPUT
-          echo "parent-run-id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
-        else
-          echo "should-run=false" >> $GITHUB_OUTPUT
-          echo "is-workflow-run=false" >> $GITHUB_OUTPUT
-          echo "parent-run-id=" >> $GITHUB_OUTPUT
-        fi
-
-  # Download artifacts from parent workflow if triggered by workflow_run
-  download-artifacts:
-    name: Download Artifacts
-    runs-on: ubuntu-latest
-    needs: [check-prerequisites]
-    if: needs.check-prerequisites.outputs.is-workflow-run == 'true'
-    steps:
-    - name: Download debug APK
-      uses: actions/download-artifact@v7
-      with:
-        pattern: app-debug-*
-        merge-multiple: true
-        github-token: ${{ github.token }}
-        run-id: ${{ needs.check-prerequisites.outputs.parent-run-id }}
-
-    - name: List downloaded files
-      run: |
-        echo "Downloaded files:"
-        ls -la app-*.apk 2>/dev/null || echo "No APK files found"
-
-    - name: Upload as reusable artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: debug-apk-for-validation
-        path: app-*.apk
-        if-no-files-found: error
-        retention-days: 1
-
   # Run unit tests (always runs, independent of APK)
   unit-tests:
     name: Unit Tests
-    needs: [check-prerequisites]
-    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -106,28 +50,25 @@ jobs:
   # Validate APK structure - reuses build from Android CI/CD when available
   validate-apk:
     name: Validate APK
-    needs: [check-prerequisites]
-    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
     uses: ./.github/workflows/reusable-validate-apk.yml
     with:
       build-type: debug
-      skip-build: ${{ needs.check-prerequisites.outputs.is-workflow-run == 'true' }}
+      skip-build: ${{ github.event_name == 'workflow_run' }}
 
   # Test on emulator - reuses APK from validate-apk (NO double-build)
   test-on-emulator:
     name: Test on Emulator
-    needs: [check-prerequisites, validate-apk]
-    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
+    needs: [validate-apk]
     uses: ./.github/workflows/reusable-test-emulator.yml
     with:
       build-type: debug
-      skip-build: true  # Always reuse - validate-apk already built/downloaded
+      skip-build: true
 
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [check-prerequisites, unit-tests, validate-apk, test-on-emulator]
-    if: always() && needs.check-prerequisites.outputs.should-run == 'true'
+    needs: [unit-tests, validate-apk, test-on-emulator]
+    if: always()
 
     steps:
     - name: Generate summary
@@ -164,7 +105,7 @@ jobs:
 
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Build Efficiency" >> $GITHUB_STEP_SUMMARY
-        if [ "${{ needs.check-prerequisites.outputs.is-workflow-run }}" == "true" ]; then
+        if [ "${{ github.event_name }}" == "workflow_run" ]; then
           echo "- ♻️ Reused APK from Android CI/CD workflow" >> $GITHUB_STEP_SUMMARY
           echo "- ⚡ No duplicate builds performed" >> $GITHUB_STEP_SUMMARY
         else

--- a/.github/workflows/reusable-test-emulator.yml
+++ b/.github/workflows/reusable-test-emulator.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: number
         default: 29
+      skip-build:
+        description: 'Skip building if APK is available'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test-on-emulator:
@@ -39,7 +44,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Build APK if not provided
-      if: inputs.apk-path == ''
+      if: inputs.apk-path == '' && inputs.skip-build == false
       run: |
         ./gradlew assemble${{ inputs.build-type == 'release' && 'Release' || 'Debug' }} --no-daemon
       timeout-minutes: 10

--- a/.github/workflows/reusable-test-emulator.yml
+++ b/.github/workflows/reusable-test-emulator.yml
@@ -22,7 +22,7 @@ on:
         description: 'Skip building if APK is available'
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   test-on-emulator:

--- a/.github/workflows/reusable-test-emulator.yml
+++ b/.github/workflows/reusable-test-emulator.yml
@@ -18,11 +18,6 @@ on:
         required: false
         type: number
         default: 29
-      skip-build:
-        description: 'Skip building if APK is available'
-        required: false
-        type: boolean
-        default: true
 
 jobs:
   test-on-emulator:
@@ -43,12 +38,6 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build APK if not provided
-      if: inputs.apk-path == '' && inputs.skip-build == false
-      run: |
-        ./gradlew assemble${{ inputs.build-type == 'release' && 'Release' || 'Debug' }} --no-daemon
-      timeout-minutes: 10
-
     - name: Find APK file
       id: find-apk
       run: |
@@ -58,7 +47,12 @@ jobs:
           APK_PATH=$(find app/build/outputs/apk/${{ inputs.build-type }} -name "*.apk" -type f | head -1)
         fi
         echo "apk_path=$APK_PATH" >> $GITHUB_OUTPUT
-        echo "Found APK: $APK_PATH"
+        if [ -n "$APK_PATH" ]; then
+          echo "Found APK: $APK_PATH"
+        else
+          echo "No APK found!"
+          exit 1
+        fi
 
     - name: Enable KVM for emulator
       run: |
@@ -66,7 +60,7 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
-    - name: Run tests on Android Emulator
+    - name: Start Android Emulator
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ inputs.api-level }}
@@ -75,17 +69,19 @@ jobs:
         profile: pixel_4
         ram-size: 2048M
         script: |
-          echo "=== Installing APK ==="
+          echo "Installing APK..."
           adb install -r ${{ steps.find-apk.outputs.apk_path }}
-          echo "=== Verifying installation ==="
-          adb shell pm list packages | grep routesnap || exit 1
-          echo "=== Launching app ==="
+
+          echo "Launching app..."
           adb shell am start -n com.routesnap.app/.MainActivity
-          echo "=== Waiting for app to start ==="
-          sleep 15
-          echo "=== Checking for crashes ==="
-          adb logcat -d | grep -E "FATAL|CRASH" | tail -20 || echo "No crashes"
-          echo "=== Taking screenshot ==="
+
+          echo "Waiting for app to start..."
+          sleep 10
+
+          echo "Checking for crashes..."
+          adb logcat -d | grep -E "FATAL|CRASH|AndroidRuntime" | tail -20 || echo "No crashes found"
+
+          echo "Taking screenshot..."
           adb shell screencap -p /data/local/tmp/screenshot.png
           adb pull /data/local/tmp/screenshot.png /tmp/emulator-screenshot.png
 

--- a/.github/workflows/reusable-test-emulator.yml
+++ b/.github/workflows/reusable-test-emulator.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: number
         default: 29
+      skip-build:
+        description: 'Skip building if APK is available'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   test-on-emulator:
@@ -37,6 +42,12 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+
+    - name: Build APK if not provided
+      if: inputs.skip-build == false
+      run: |
+        ./gradlew assemble${{ inputs.build-type == 'release' && 'Release' || 'Debug' }} --no-daemon
+      timeout-minutes: 10
 
     - name: Find APK file
       id: find-apk

--- a/.github/workflows/reusable-validate-apk.yml
+++ b/.github/workflows/reusable-validate-apk.yml
@@ -17,7 +17,7 @@ on:
         description: 'Skip building if APK is available'
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   validate-apk:

--- a/.github/workflows/reusable-validate-apk.yml
+++ b/.github/workflows/reusable-validate-apk.yml
@@ -14,10 +14,10 @@ on:
         type: string
         default: 'debug'
       skip-build:
-        description: 'Skip building if APK is provided'
+        description: 'Skip building if APK is available'
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   validate-apk:

--- a/.github/workflows/reusable-validate-apk.yml
+++ b/.github/workflows/reusable-validate-apk.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: 'debug'
+      skip-build:
+        description: 'Skip building if APK is provided'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   validate-apk:
@@ -34,7 +39,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Build APK if not provided
-      if: inputs.apk-path == ''
+      if: inputs.apk-path == '' && inputs.skip-build == false
       run: |
         ./gradlew assemble${{ inputs.build-type == 'release' && 'Release' || 'Debug' }} --no-daemon
       timeout-minutes: 10
@@ -110,4 +115,4 @@ jobs:
       with:
         name: validated-apk-${{ github.run_id }}
         path: ${{ steps.find-apk.outputs.apk_path }}
-        if-no-files-found: ignore
+        if-no-files-found: error


### PR DESCRIPTION
## Summary
Workflow optimization to eliminate ALL duplicate APK builds.

## Final Architecture

APK Build Flow for PR:
1. android-build.yml builds 1 debug APK
2. code-quality.yml runs (NO APK builds)
3. apk-validation.yml triggered via workflow_run (reuses APK)

## Build Efficiency

| Trigger | Debug Builds | Release Builds | Total |
|---------|--------------|----------------|-------|
| PR | 1 | 0 (skipped) | 1 |
| Push to main | 1 | 1 | 2 |
| Tag | 0 | 1 (reuse) | 1 |

Before: 4 APK builds per PR
After: 1 APK build per PR (75% reduction)

## Critical Fixes

1. apk-validation.yml - workflow_run ONLY (removed pull_request trigger)
2. android-build.yml - Skip release on PR
3. android-build.yml - Remove duplicate lint/dependency-check jobs

## Test Coverage

| Test Type | Workflow | Status |
|-----------|----------|--------|
| Unit Tests | apk-validation.yml | PASS |
| APK Validation | apk-validation.yml | PASS |
| Emulator Smoke | apk-validation.yml | PASS |
| Lint | code-quality.yml | PASS |
| Dependencies | code-quality.yml | PASS |

## All Checks Passing
- Android CI/CD (2m 52s)
- Code Quality (1m 32s)
- APK Validation Tests (via workflow_run)