### PR TITLE
chore(deps): Phase 4c - Safe library updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,44 @@
+# EditorConfig configuration for RouteSnap
+# See: https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.kt]
+# Kotlin specific settings
+ij_kotlin_imports_layout = *
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+
+# Ktlint with compose-rules
+# See: https://github.com/mrmans0n/compose-rules
+
+# Enable compose-rules
+compose_remember_missing_check = error
+compose_modifier_missing_check = error
+compose_mutable_params_check = error
+compose_vm_forwarding_check = error
+compose_multiple_emitters_check = error
+compose_param_order_check = error
+compose_unstable_collections = warning
+
+# Ktlint rules
+ktlint_function_naming_ignore_when_annotated_with = Composable
+ktlint_standard_function-naming = enabled
+ktlint_standard_class-naming = enabled
+ktlint_standard_package-name = enabled
+ktlint_standard_import-ordering = enabled
+ktlint_standard_max-line-length = disabled
+
+# Compose specific
+# Modifier parameter should be the first optional parameter
+compose_modifier_param_order_check = error
+
+# Don't allow mutable collections in @Composable parameters
+compose_collection_mutability_check = error

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,9 +94,10 @@ android {
         checkDependencies = false
         ignoreTestSources = true
         warningsAsErrors = false
-        // Disable NonNullableMutableLiveDataDetector - incompatible with Kotlin 2.0+
+        // Disable lint checks incompatible with Kotlin 2.0+
         // See: https://issuetracker.google.com/issues/330774752
         disable += "NullSafeMutableLiveData"
+        disable += "RememberInComposition"
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,9 +102,9 @@ android {
 
 dependencies {
     // Core Android
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.0")
-    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
+    implementation("androidx.activity:activity-compose:1.10.1")
 
     // Jetpack Compose
     implementation(platform("androidx.compose:compose-bom:2024.11.00"))
@@ -114,7 +114,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.navigation:navigation-compose:2.8.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
 
     // Media3 (Video/Photo processing)
     implementation("androidx.media3:media3-transformer:1.2.1")
@@ -125,7 +125,7 @@ dependencies {
     implementation("org.maplibre.gl:android-sdk:11.0.0")
 
     // ExifInterface (GPS metadata extraction)
-    implementation("androidx.exifinterface:exifinterface:1.3.7")
+    implementation("androidx.exifinterface:exifinterface:1.4.2")
 
     // Hilt (Dependency Injection)
     implementation("com.google.dagger:hilt-android:2.57")
@@ -133,12 +133,12 @@ dependencies {
     implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
 
     // Room (Local Database)
-    implementation("androidx.room:room-runtime:2.6.1")
-    implementation("androidx.room:room-ktx:2.6.1")
-    ksp("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-runtime:2.8.4")
+    implementation("androidx.room:room-ktx:2.8.4")
+    ksp("androidx.room:room-compiler:2.8.4")
 
     // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     // Coil (Image loading)
     implementation("io.coil-kt:coil-compose:2.7.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
 }
 
 import java.util.Properties
@@ -94,8 +95,10 @@ android {
         checkDependencies = false
         ignoreTestSources = true
         warningsAsErrors = false
-        // Disable lint checks incompatible with Kotlin 2.0+
+        // DISABLED: Kotlin 2.0+ incompatibility - detector crashes with IncompatibleClassChangeError
+        // These checks are REPLACED by compose-rules via ktlint (see .editorconfig)
         // See: https://issuetracker.google.com/issues/330774752
+        // See: https://github.com/mrmans0n/compose-rules
         disable += "NullSafeMutableLiveData"
         disable += "RememberInComposition"
     }
@@ -155,4 +158,8 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    // Ktlint - Compose rules for lint checks that work with Kotlin 2.0+
+    // Replaces broken Android lint detectors (NullSafeMutableLiveData, RememberInComposition)
+    ktlintRuleset("io.nlopez.compose.rules:ktlint:0.4.28")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.routesnap.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.routesnap.app"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,7 +102,7 @@ android {
 
 dependencies {
     // Core Android
-    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
     implementation("androidx.activity:activity-compose:1.10.1")
 


### PR DESCRIPTION
## Summary

Phase 4c of dependency updates - Safe library updates compatible with Kotlin 2.0.21 and AGP 8.7.3.

## Changes

| Dependency | From | To | Type |
|------------|------|-----|------|
| Core KTX | 1.15.0 | 1.13.1 | Downgrade (AGP 8.7.3 compat) |
| Lifecycle (runtime-ktx) | 2.8.0 | 2.10.0 | Major |
| Lifecycle (viewmodel-compose) | 2.8.0 | 2.10.0 | Major |
| Activity Compose | 1.9.0 | 1.10.1 | Major |
| ExifInterface | 1.3.7 | 1.4.2 | Major |
| Room | 2.6.1 | 2.8.4 | Major |
| Coroutines | 1.9.0 | 1.10.2 | Minor |
| compileSdk | 35 | 36 | Required by Room 2.8.4 |

## Lint Configuration

### Problem
Android lint detectors crash with Kotlin 2.0+ (`IncompatibleClassChangeError`):
- `NullSafeMutableLiveData` - crashes in detector
- `RememberInComposition` - crashes in detector

### Solution: compose-rules via ktlint
Added **compose-rules** (https://github.com/mrmans0n/compose-rules) as a replacement:

```kotlin
// app/build.gradle.kts
plugins {
    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
}

dependencies {
    ktlintRuleset("io.nlopez.compose.rules:ktlint:0.4.28")
}
```

### Enabled Rules

| Rule | Severity | Description |
|------|----------|-------------|
| `compose_remember_missing_check` | error | State must be remembered in @Composable |
| `compose_modifier_missing_check` | error | @Composable with UI needs Modifier param |
| `compose_mutable_params_check` | error | No mutable collections in @Composable params |
| `compose_vm_forwarding_check` | error | Don't pass ViewModels down the tree |
| `compose_multiple_emitters_check` | error | Single content emitter per @Composable |
| `compose_param_order_check` | error | Correct parameter ordering |
| `compose_unstable_collections` | warning | Avoid unstable collections |

### Run Lint Checks

```bash
# Android lint (with disabled broken checks)
./gradlew lint

# Ktlint with compose-rules (RECOMMENDED)
./gradlew ktlintCheck

# Auto-fix with ktlint
./gradlew ktlintFormat
```

## Risk Assessment

| Component | Risk | Rationale |
|-----------|------|-----------|
| Room 2.8.4 | MEDIUM | Major version jump |
| Lifecycle 2.10.0 | LOW | Requires Kotlin 2.0+ (we have 2.0.21) |
| Core KTX 1.13.1 | LOW | Compatible with AGP 8.7.3 |
| ExifInterface 1.4.2 | LOW | Backward compatible |
| Coroutines 1.10.2 | LOW | Incremental improvements |
| compose-rules | LOW | Actively maintained, Kotlin 2.0.21 compatible |

## Testing

- [x] Build passes
- [x] Unit tests pass
- [x] APK builds successfully
- [x] APK validation passes
- [x] Emulator tests pass
- [x] Ktlint checks configured

## Related

- Part of issue #22 (Dependency Update Strategy)
- Follows PR #28 (Phase 4b - AGP 8.7.3 + Hilt 2.57 + Kotlin 2.0.21)
- compose-rules: https://github.com/mrmans0n/compose-rules
