### PR TITLE
Phase 5: Add detekt for static code analysis

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,126 @@
+name: Code Quality
+
+on:
+  pull_request:
+    branches: ["main", "master", "develop"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ============================================================================
+  # Ktlint - Code formatting and style
+  # ============================================================================
+
+  ktlint:
+    name: Ktlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Run ktlintCheck
+      run: ./gradlew ktlintCheck --no-daemon
+
+    - name: Upload ktlint report
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: ktlint-report-${{ github.run_id }}
+        path: app/build/reports/ktlint/
+        if-no-files-found: ignore
+
+  # ============================================================================
+  # Detekt - Static code analysis
+  # ============================================================================
+
+  detekt:
+    name: Detekt
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Run detekt
+      run: ./gradlew detekt --no-daemon
+
+    - name: Upload detekt report (SARIF for GitHub annotations)
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: app/build/reports/detekt/detekt.sarif
+        category: detekt
+
+    - name: Upload detekt HTML report
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: detekt-report-${{ github.run_id }}
+        path: app/build/reports/detekt/detekt.html
+        if-no-files-found: ignore
+
+  # ============================================================================
+  # Summary
+  # ============================================================================
+
+  summary:
+    name: Code Quality Summary
+    runs-on: ubuntu-latest
+    needs: [ktlint, detekt]
+    if: always()
+
+    steps:
+    - name: Generate summary
+      run: |
+        echo "## Code Quality Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "### Ktlint (Formatting & Style)" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ needs.ktlint.result }}" == "success" ]; then
+          echo "✓ Passed - No formatting issues" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.ktlint.result }}" == "failure" ]; then
+          echo "✗ Failed - Formatting issues found" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "⚠️ Cancelled or skipped" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Detekt (Static Analysis)" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ needs.detekt.result }}" == "success" ]; then
+          echo "✓ Passed - No code smells detected" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.detekt.result }}" == "failure" ]; then
+          echo "✗ Failed - Code smells detected (see Files Changed for inline annotations)" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "⚠️ Cancelled or skipped" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Reports" >> $GITHUB_STEP_SUMMARY
+        echo "- Detekt SARIF: Uploaded to GitHub (check Files Changed tab for inline annotations)" >> $GITHUB_STEP_SUMMARY
+        echo "- Detekt HTML: Available in workflow artifacts" >> $GITHUB_STEP_SUMMARY
+        echo "- Ktlint: Available in workflow artifacts" >> $GITHUB_STEP_SUMMARY

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,6 +172,7 @@ dependencies {
 // Ktlint configuration - use ktlint 1.8.0 for compose-rules compatibility
 ktlint {
     version.set("1.8.0")
+    ignoreFailures.set(true)  // Report issues but don't fail build
 }
 
 // Detekt configuration
@@ -182,7 +183,7 @@ detekt {
     buildUponDefaultConfig = true
     allRules = false
     baseline = file("$rootDir/config/detekt/baseline.xml")
-    ignoreFailures = false
+    ignoreFailures = true  // Report issues but don't fail build
 
     // Skip detekt on release builds (faster CI)
     ignoredBuildTypes = listOf("release")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,6 +172,13 @@ dependencies {
 // Ktlint configuration - use ktlint 1.8.0 for compose-rules compatibility
 ktlint {
     version.set("1.8.0")
+    kotlinScriptAdditionalPaths {
+        include(fileTree("scripts/"))
+    }
+    filter {
+        exclude("**/scripts/**")
+        include("**/*.kt")
+    }
 }
 
 // Detekt configuration

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,8 +133,8 @@ dependencies {
     implementation("androidx.exifinterface:exifinterface:1.4.2")
 
     // Hilt (Dependency Injection)
-    implementation("com.google.dagger:hilt-android:2.52")
-    ksp("com.google.dagger:hilt-android-compiler:2.52")
+    implementation("com.google.dagger:hilt-android:2.58")
+    ksp("com.google.dagger:hilt-android-compiler:2.58")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
     // Room (Local Database)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,7 +118,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation("androidx.navigation:navigation-compose:2.9.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
 
     // Media3 (Video/Photo processing)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,8 +133,8 @@ dependencies {
     implementation("androidx.exifinterface:exifinterface:1.4.2")
 
     // Hilt (Dependency Injection)
-    implementation("com.google.dagger:hilt-android:2.58")
-    ksp("com.google.dagger:hilt-android-compiler:2.58")
+    implementation("com.google.dagger:hilt-android:2.57")
+    ksp("com.google.dagger:hilt-android-compiler:2.57")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
     // Room (Local Database)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,7 +172,6 @@ dependencies {
 // Ktlint configuration - use ktlint 1.8.0 for compose-rules compatibility
 ktlint {
     version.set("1.8.0")
-    ignoreFailures.set(true)  // Report issues but don't fail build
 }
 
 // Detekt configuration
@@ -183,7 +182,7 @@ detekt {
     buildUponDefaultConfig = true
     allRules = false
     baseline = file("$rootDir/config/detekt/baseline.xml")
-    ignoreFailures = true  // Report issues but don't fail build
+    ignoreFailures = false
 
     // Skip detekt on release builds (faster CI)
     ignoredBuildTypes = listOf("release")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
 import java.util.Properties
@@ -167,6 +167,11 @@ dependencies {
     // Detekt - Compose rules for static analysis (works with Kotlin 2.0+)
     // Complements ktlint (formatting) with deep code analysis
     detektPlugins("io.nlopez.compose.rules:detekt:0.4.28")
+}
+
+// Ktlint configuration - use ktlint 1.8.0 for compose-rules compatibility
+ktlint {
+    version.set("1.8.0")
 }
 
 // Detekt configuration

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,9 +133,9 @@ dependencies {
     implementation("androidx.exifinterface:exifinterface:1.4.2")
 
     // Hilt (Dependency Injection)
-    implementation("com.google.dagger:hilt-android:2.57")
-    ksp("com.google.dagger:hilt-android-compiler:2.57")
-    implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
+    implementation("com.google.dagger:hilt-android:2.52")
+    ksp("com.google.dagger:hilt-android-compiler:2.52")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
     // Room (Local Database)
     implementation("androidx.room:room-runtime:2.8.4")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
 }
 
 import java.util.Properties
@@ -154,4 +155,34 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    // Detekt - Compose rules for static analysis (works with Kotlin 2.0+)
+    // Complements ktlint (formatting) with deep code analysis
+    detektPlugins("io.nlopez.compose.rules:detekt:0.4.28")
+}
+
+// Detekt configuration
+detekt {
+    toolVersion = "1.23.8"
+    source.setFrom("src/main/java", "src/test/java")
+    config.setFrom("$rootDir/config/detekt/detekt.yml")
+    buildUponDefaultConfig = true
+    allRules = false
+    baseline = file("$rootDir/config/detekt/baseline.xml")
+    ignoreFailures = false
+
+    // Skip detekt on release builds (faster CI)
+    ignoredBuildTypes = listOf("release")
+}
+
+// Configure detekt reports
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    reports {
+        html.required.set(true)
+        html.outputLocation.set(file("build/reports/detekt/detekt.html"))
+        sarif.required.set(true)  // For GitHub PR annotations
+        sarif.outputLocation.set(file("build/reports/detekt/detekt.sarif"))
+        txt.required.set(false)
+        xml.required.set(false)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
-    id("com.google.dagger.hilt.android") version "2.58" apply false
+    id("com.google.dagger.hilt.android") version "2.57" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
-    id("com.google.dagger.hilt.android") version "2.57" apply false
+    id("com.google.dagger.hilt.android") version "2.52" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
-    id("com.google.dagger.hilt.android") version "2.52" apply false
+    id("com.google.dagger.hilt.android") version "2.58" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.google.dagger.hilt.android") version "2.57" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
 }

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues>
-    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$@Suppress("BlockingMethodInNonBlockingContext") override suspend fun getTrip(id: String): TripManifest?</ID>
+    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$try</ID>
     <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
     <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
     <ID>TooGenericExceptionCaught:RenderViewModel.kt$RenderViewModel$try</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues>
+    <ID>TooGenericExceptionCaught:TripRepository.kt$TripRepository$@Throws(IOException::class, SecurityException::class) override suspend fun getTrip(id: String): TripManifest?</ID>
+    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$@Suppress("BlockingMethodInNonBlockingContext") private fun extractMetadata(uri: Uri, context: Context): MediaMetadata?</ID>
+    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$try</ID>
+    <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
+    <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
+    <ID>TooGenericExceptionCaught:RenderViewModel.kt$RenderViewModel$try</ID>
+    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$try</ID>
+  </ManuallySuppressedIssues>
+  <CurrentIssues>
+  </CurrentIssues>
+</SmellBaseline>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues>
-    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$try</ID>
-    <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
-    <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
-    <ID>TooGenericExceptionCaught:RenderViewModel.kt$RenderViewModel$try</ID>
-    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$try</ID>
-    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$try</ID>
-    <ID>TooGenericExceptionCaught:TripRepository.kt$TripRepository$try</ID>
+    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$try</ID>
+    <ID>TooGenericExceptionCaught:PickerViewModel.kt$try</ID>
+    <ID>TooGenericExceptionCaught:PickerViewModel.kt$try</ID>
+    <ID>TooGenericExceptionCaught:RenderViewModel.kt$try</ID>
+    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$try</ID>
+    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$try</ID>
+    <ID>TooGenericExceptionCaught:TripRepository.kt$try</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
   </CurrentIssues>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues>
-    <ID>TooGenericExceptionCaught:TripRepository.kt$TripRepository$@Throws(IOException::class, SecurityException::class) override suspend fun getTrip(id: String): TripManifest?</ID>
-    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$@Suppress("BlockingMethodInNonBlockingContext") private fun extractMetadata(uri: Uri, context: Context): MediaMetadata?</ID>
-    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$try</ID>
+    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$try</ID>
     <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
     <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
     <ID>TooGenericExceptionCaught:RenderViewModel.kt$RenderViewModel$try</ID>
-    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$try</ID>
+    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$try</ID>
+    <ID>TooGenericExceptionCaught:MetadataExtractor.kt$MetadataExtractor$try</ID>
+    <ID>TooGenericExceptionCaught:TripRepository.kt$TripRepository$try</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
   </CurrentIssues>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues>
-    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$try</ID>
+    <ID>TooGenericExceptionCaught:TimelineViewModel.kt$TimelineViewModel$@Suppress("BlockingMethodInNonBlockingContext") override suspend fun getTrip(id: String): TripManifest?</ID>
     <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
     <ID>TooGenericExceptionCaught:PickerViewModel.kt$PickerViewModel$try</ID>
     <ID>TooGenericExceptionCaught:RenderViewModel.kt$RenderViewModel$try</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -95,7 +95,7 @@ naming:
     active: true
   InvalidPackageDeclaration:
     active: true
-    rootPackage: ["com.routesnap"]
+    rootPackage: "com.routesnap"
   NoNameShadowing:
     active: true
   NonBooleanPropertyPrefixedWithIs:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -10,17 +10,13 @@ config:
   validation: true
   warningsAsErrors: false
 
-# Disable formatting rules - ktlint handles these
-formatting:
-  active: false
-
 # Code complexity analysis
 complexity:
   active: true
   ComplexCondition:
     active: true
     threshold: 5
-  ComplexMethod:
+  CyclomaticComplexMethod:
     active: true
     threshold: 15
     ignoreSingleWhenExpression: true
@@ -235,7 +231,7 @@ style:
     active: true
   OptionalAbstractKeyword:
     active: true
-  OptionalWhenBraces:
+  BracesOnWhenStatements:
     active: true
   PreferToOverPairSyntax:
     active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,376 @@
+# Detekt configuration for RouteSnap
+# Complements existing ktlint setup (formatting handled by ktlint)
+# See: https://detekt.dev/docs/introduction/configurations/
+
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+
+config:
+  validation: true
+  warningsAsErrors: false
+
+# Disable formatting rules - ktlint handles these
+formatting:
+  active: false
+
+# Code complexity analysis
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 5
+  ComplexMethod:
+    active: true
+    threshold: 15
+    ignoreSingleWhenExpression: true
+  LongMethod:
+    active: true
+    threshold: 60
+    ignoreAnnotated: ["Composable"]
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+    ignoreAnnotated: ["Composable"]
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 11
+    thresholdInClasses: 11
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreAnnotated: ["Composable"]
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: "_|(ignore|expected).*"
+  EmptyClassBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: false
+
+exceptions:
+  active: true
+  PrintStackTrace:
+    active: true
+  RethrowCaughtException:
+    active: true
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - InterruptedException
+      - NumberFormatException
+      - ParseException
+  ThrowingExceptionFromFinally:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    allowedExceptionNameRegex: "_|(ignore|expected).*"
+
+naming:
+  active: true
+  # Disable naming rules that overlap with ktlint
+  FunctionNaming:
+    active: false
+  ClassNaming:
+    active: false
+  PackageNaming:
+    active: false
+  # Keep detekt-specific checks
+  BooleanPropertyNaming:
+    active: true
+  ConstructorParameterNaming:
+    active: true
+  InvalidPackageDeclaration:
+    active: true
+    rootPackage: ["com.routesnap"]
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+  VariableMinLength:
+    active: true
+    minimumVariableNameLength: 1
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  ForEachOnRange:
+    active: true
+  SpreadOperator:
+    active: true
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  AvoidReferentialEquality:
+    active: true
+  CastNullableToNonNullableType:
+    active: true
+  Deprecation:
+    active: true
+  DontDowncastCollectionTypes:
+    active: true
+  DoubleMutabilityForCollection:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  IgnoredReturnValue:
+    active: true
+  ImplicitDefaultLocale:
+    active: true
+  LateinitUsage:
+    active: true
+    ignoreAnnotated: ["Inject"]
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  NullableToStringCall:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: true
+  UnnecessaryNotNullCheck:
+    active: true
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+  UnsafeCast:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  # Disable style rules that overlap with ktlint
+  # Keep detekt-specific checks
+  CanBeNonNullable:
+    active: true
+  CascadingCallWrapping:
+    active: true
+  ClassOrdering:
+    active: true
+  DataClassShouldBeImmutable:
+    active: true
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+    maxDestructuringEntries: 3
+  EqualsNullCall:
+    active: true
+  ExplicitCollectionElementAccessMethod:
+    active: true
+  ForbiddenComment:
+    active: true
+    comments:
+      - "FIXME"
+      - "STOPSHIP"
+      - "TODO"
+  ForbiddenMethodCall:
+    active: true
+    methods:
+      - "kotlin.io.print"
+      - "kotlin.io.println"
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    ignoreNumbers:
+      - "-1"
+      - "0"
+      - "1"
+      - "2"
+      - "10"
+      - "100"
+      - "1000"
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreExtensionFunctions: true
+  MaxLineLength:
+    active: false  # ktlint handles this
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: false  # ktlint handles this
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: false  # ktlint handles this
+  NullableBooleanCheck:
+    active: true
+  ObjectLiteralToLambda:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalWhenBraces:
+    active: true
+  PreferToOverPairSyntax:
+    active: true
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: true
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifierRule:
+    active: true
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions:
+      - "equals"
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  ThrowsCount:
+    active: true
+    max: 2
+    excludeGuardClauses: false
+  UnderscoresInNumericLiterals:
+    active: false
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: true
+  UnnecessaryApply:
+    active: true
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: true
+  UnnecessaryLet:
+    active: true
+  UseAnyOrNoneInsteadOfFind:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseCheckOrError:
+    active: true
+  UseDataClass:
+    active: true
+    allowVars: false
+  UseEmptyCounterpart:
+    active: true
+  UseIfEmptyOrIfBlank:
+    active: true
+  UseIsNullOrEmpty:
+    active: true
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+    ignoreAnnotated: ["Parameter"]
+  WildcardImport:
+    active: true
+    excludeImports:
+      - "java.util.*"
+
+# Compose-specific rules (via compose-rules plugin)
+# These replace the broken Android lint detectors
+Compose:
+  ComposableAnnotationNaming:
+    active: true
+  ComposableNaming:
+    active: true
+  ComposableParamOrder:
+    active: true
+  CompositionLocalAllowlist:
+    active: true
+  CompositionLocalNaming:
+    active: true
+  ContentEmitterReturningValues:
+    active: true
+  DefaultsVisibility:
+    active: true
+  LambdaParameterEventTrailing:
+    active: true
+  LambdaParameterInRestartableEffect:
+    active: true
+  ModifierClickableOrder:
+    active: true
+  ModifierComposed:
+    active: true
+  ModifierMissing:
+    active: true
+  ModifierNaming:
+    active: true
+  ModifierNotUsedAtRoot:
+    active: true
+  ModifierReused:
+    active: true
+  ModifierWithoutDefault:
+    active: true
+  MultipleEmitters:
+    active: true
+  MutableParams:
+    active: true
+  MutableStateAutoboxing:
+    active: true
+  MutableStateParam:
+    active: true
+  ParameterNaming:
+    active: true
+  PreviewAnnotationNaming:
+    active: true
+  PreviewPublic:
+    active: true
+  RememberMissing:
+    active: true
+  RememberContentMissing:
+    active: true
+  ViewModelForwarding:
+    active: true
+  ViewModelInjection:
+    active: true
+  # Opt-in rules (disabled by default)
+  UnstableCollections:
+    active: false  # Enable if not using strong skipping


### PR DESCRIPTION
## Phase 5: Detekt Integration for Static Code Analysis

### Summary

This PR adds **detekt** static code analysis tool to complement the existing ktlint setup. Detekt provides deep code analysis that ktlint doesn't cover, while ktlint handles fast formatting checks.

### Why Both Detekt and Ktlint?

| Tool | Purpose | Speed | Best For |
|------|---------|-------|----------|
| **ktlint** | Code formatting & style | Fast (<5s) | Pre-commit hooks, CI formatting |
| **detekt** | Static analysis & code smells | Slower (~20s) | CI/CD, PR checks, deep analysis |

**Industry Standard:** Google, Square, Airbnb, and Uber all use both tools together for maximum code quality coverage.

### Changes

#### 1. Dependencies Added

**Root `build.gradle.kts`:**
```kotlin
id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
```

**App `build.gradle.kts`:**
```kotlin
id("io.gitlab.arturbosch.detekt") version "1.23.8"
detektPlugins("io.nlopez.compose.rules:detekt:0.4.28")
```

#### 2. Configuration Files

**`config/detekt/detekt.yml`** - Optimized configuration:
- ✅ Formatting rules **disabled** (ktlint handles these)
- ✅ Code smell detection **enabled**
- ✅ Complexity analysis **enabled**
- ✅ Potential bug detection **enabled**
- ✅ Compose rules **enabled** (replaces broken Android lint detectors)

**Key Rules Enabled:**
- `complexity` - Complex methods, long methods, too many functions
- `coroutines` - GlobalScope usage, redundant suspend, sleep instead of delay
- `empty-blocks` - Empty catch, function, class blocks
- `exceptions` - Generic exceptions, swallowed exceptions, printStackTrace
- `potential-bugs` - Unsafe casts, unreachable code, unused operators
- `style` - Redundant visibility, unnecessary applies, magic numbers
- `Compose` - Remember missing, Modifier missing, ViewModel forwarding, etc.

#### 3. Detekt Configuration

**`app/build.gradle.kts`:**
```kotlin
detekt {
    toolVersion = "1.23.8"
    config.setFrom("$rootDir/config/detekt/detekt.yml")
    baseline = file("$rootDir/config/detekt/baseline.xml")
    ignoredBuildTypes = listOf("release")  // Faster CI
}
```

**Reports Configured:**
- HTML report: `build/reports/detekt/detekt.html`
- SARIF report: `build/reports/detekt/detekt.sarif` (for GitHub PR annotations)

### Rule Overlap Avoidance

**Disabled in detekt** (ktlint handles these):
- All `formatting` rules
- `naming.FunctionNaming`, `ClassNaming`, `PackageNaming`
- `style.MaxLineLength`, `ModifierOrder`, `NewLineAtEndOfFile`

**Enabled in detekt** (complementary to ktlint):
- All code smell detectors
- Complexity checks
- Exception handling
- Potential bugs
- Performance anti-patterns
- Compose-specific rules (via compose-rules plugin)

### Compose Rules (Replaces Broken Android Lint)

These detekt rules replace the broken Android lint detectors that crash with Kotlin 2.0+:

| Broken Android Lint | Detekt Replacement |
|---------------------|-------------------|
| `NullSafeMutableLiveData` | `compose:MutableParams` |
| `RememberInComposition` | `compose:RememberMissing` |
| N/A | `compose:ModifierMissing` (bonus) |
| N/A | `compose:ViewModelForwarding` (bonus) |
| N/A | `compose:MultipleEmitters` (bonus) |

### Usage

```bash
# Run detekt analysis
./gradlew detekt

# Generate baseline (ignore existing issues)
./gradlew detektBaseline

# Run with type resolution (more accurate)
./gradlew detektMain
```

### Next Steps

1. **Generate baseline** after first run:
   ```bash
   ./gradlew detektBaseline
   ```

2. **Review initial findings**:
   ```bash
   ./gradlew detekt
   open app/build/reports/detekt/detekt.html
   ```

3. **Fix critical issues** in new/changed code only

4. **Add CI workflow** (follow-up PR):
   - Run detekt on PRs
   - Upload SARIF for GitHub annotations
   - Quality gates for new code

### Testing Checklist

- [ ] `./gradlew detekt` runs successfully
- [ ] `./gradlew detektBaseline` generates baseline.xml
- [ ] HTML report generated at `build/reports/detekt/detekt.html`
- [ ] SARIF report generated at `build/reports/detekt/detekt.sarif`
- [ ] No build failures
- [ ] Detekt skips release builds (faster CI)

### Related

- Part of issue #22 (Dependency Update Strategy) - Phase 5
- Follows PR #39 (Phase 4c - Library updates + compose-rules via ktlint)
- Detekt docs: https://detekt.dev
- Compose Rules: https://github.com/mrmans0n/compose-rules
- Kotlin 2.0.21 compatible: ✅
- AGP 8.7.3 compatible: ✅

### Future Work (Media3 Implementation)

This PR sets up the lint infrastructure. Media3 implementation will follow in a separate PR:
- CanvasOverlay for map polyline animation
- ScaleToFitTransformation (Ken Burns effect)
- AudioMixEffect (audio ducking)
- Foreground Service integration
