### PR TITLE
feat: landscape photo handling — auto-pan + zoom-to-rect (#88)

### DIFF
--- a/app/src/main/java/com/routesnap/app/MainActivity.kt
+++ b/app/src/main/java/com/routesnap/app/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.routesnap.app.ui.picker.PhotoPickerScreen
 import com.routesnap.app.ui.render.RenderScreen
+import com.routesnap.app.ui.review.PhotoReviewScreen
 import com.routesnap.app.ui.share.ShareScreen
 import com.routesnap.app.ui.style.StyleScreen
 import com.routesnap.app.ui.theme.RouteSnapTheme
@@ -79,6 +80,21 @@ fun RouteSnapNavGraph(
                 tripId = tripId,
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToStyle = { navController.navigate("style/$tripId") },
+                onNavigateToPhotoReview = { segmentId ->
+                    navController.navigate("review/$tripId/$segmentId")
+                },
+            )
+        }
+
+        composable(
+            route = "review/{tripId}/{segmentId}",
+            arguments = listOf(
+                navArgument("tripId") { type = NavType.StringType },
+                navArgument("segmentId") { type = NavType.StringType },
+            ),
+        ) {
+            PhotoReviewScreen(
+                onNavigateBack = { navController.popBackStack() },
             )
         }
 

--- a/app/src/main/java/com/routesnap/app/MainActivity.kt
+++ b/app/src/main/java/com/routesnap/app/MainActivity.kt
@@ -88,10 +88,11 @@ fun RouteSnapNavGraph(
 
         composable(
             route = "review/{tripId}/{segmentId}",
-            arguments = listOf(
-                navArgument("tripId") { type = NavType.StringType },
-                navArgument("segmentId") { type = NavType.StringType },
-            ),
+            arguments =
+                listOf(
+                    navArgument("tripId") { type = NavType.StringType },
+                    navArgument("segmentId") { type = NavType.StringType },
+                ),
         ) {
             PhotoReviewScreen(
                 onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/java/com/routesnap/app/data/exif/MetadataExtractor.kt
+++ b/app/src/main/java/com/routesnap/app/data/exif/MetadataExtractor.kt
@@ -189,16 +189,24 @@ class MetadataExtractor(
         }
 
     /**
-     * Extract image dimensions from EXIF
+     * Extract image dimensions from EXIF, swapping width/height for 90°/270° rotations
+     * so that the returned values reflect the displayed (post-rotation) orientation.
      */
     private fun extractDimensions(
         exif: ExifInterface,
     ): Pair<Int?, Int?> {
-        val width =
+        val rawWidth =
             exif.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, -1).takeIf { it != -1 }
-        val height =
+        val rawHeight =
             exif.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, -1).takeIf { it != -1 }
-        return width to height
+        val orientation =
+            exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        val rotated =
+            orientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+                orientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+                orientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+                orientation == ExifInterface.ORIENTATION_TRANSVERSE
+        return if (rotated) rawHeight to rawWidth else rawWidth to rawHeight
     }
 
     /**

--- a/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
+++ b/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
@@ -14,6 +14,7 @@ import com.routesnap.app.domain.model.TemplatePreset
 import com.routesnap.app.domain.model.TransitionType
 import com.routesnap.app.domain.model.TripManifest
 import com.routesnap.app.domain.model.TripSegment
+import com.routesnap.app.domain.model.ZoomRect
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
@@ -90,6 +91,25 @@ class TripRepository(
     ) {
         val trip = getTripById(tripId) ?: return
         saveTrip(trip.copy(template = template, aspectRatio = aspectRatio, transitionOverride = transitionOverride))
+    }
+
+    suspend fun updateSegmentZoomRects(
+        tripId: String,
+        segmentId: String,
+        startRect: ZoomRect,
+        endRect: ZoomRect,
+    ) {
+        val trip = getTripById(tripId) ?: return
+        val updated = trip.copy(
+            segments = trip.segments.map { seg ->
+                if (seg.id == segmentId) {
+                    seg.copy(startZoomRect = startRect, endZoomRect = endRect, isReviewed = true)
+                } else {
+                    seg
+                }
+            },
+        )
+        saveTrip(updated)
     }
 
     /**

--- a/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
+++ b/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
@@ -100,15 +100,17 @@ class TripRepository(
         endRect: ZoomRect,
     ) {
         val trip = getTripById(tripId) ?: return
-        val updated = trip.copy(
-            segments = trip.segments.map { seg ->
-                if (seg.id == segmentId) {
-                    seg.copy(startZoomRect = startRect, endZoomRect = endRect, isReviewed = true)
-                } else {
-                    seg
-                }
-            },
-        )
+        val updated =
+            trip.copy(
+                segments =
+                    trip.segments.map { seg ->
+                        if (seg.id == segmentId) {
+                            seg.copy(startZoomRect = startRect, endZoomRect = endRect, isReviewed = true)
+                        } else {
+                            seg
+                        }
+                    },
+            )
         saveTrip(updated)
     }
 

--- a/app/src/main/java/com/routesnap/app/domain/clustering/ClusteringAlgorithm.kt
+++ b/app/src/main/java/com/routesnap/app/domain/clustering/ClusteringAlgorithm.kt
@@ -6,6 +6,7 @@ import com.routesnap.app.domain.model.Cluster
 import com.routesnap.app.domain.model.LatLng
 import com.routesnap.app.domain.model.SegmentType
 import com.routesnap.app.domain.model.TripSegment
+import com.routesnap.app.domain.model.ZoomRect
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -260,6 +261,14 @@ class ClusteringAlgorithm(
                         null
                     }
 
+                val isLandscape = (photoAspectRatio ?: 1f) > 1f
+                val (defaultStartRect, defaultEndRect) =
+                    if (segmentType == SegmentType.PHOTO && !isLandscape) {
+                        ZoomRect.defaultPair(order)
+                    } else {
+                        Pair(null, null)
+                    }
+
                 segments.add(
                     TripSegment(
                         type = segmentType,
@@ -271,6 +280,8 @@ class ClusteringAlgorithm(
                         timestamp = metadata.timestamp,
                         order = order++,
                         photoAspectRatio = photoAspectRatio,
+                        startZoomRect = defaultStartRect,
+                        endZoomRect = defaultEndRect,
                     ),
                 )
             }

--- a/app/src/main/java/com/routesnap/app/domain/clustering/ClusteringAlgorithm.kt
+++ b/app/src/main/java/com/routesnap/app/domain/clustering/ClusteringAlgorithm.kt
@@ -251,6 +251,15 @@ class ClusteringAlgorithm(
                         config.photoDurationMs
                     }
 
+                val photoAspectRatio =
+                    if (segmentType == SegmentType.PHOTO &&
+                        metadata.width != null && metadata.height != null && metadata.height > 0
+                    ) {
+                        metadata.width.toFloat() / metadata.height.toFloat()
+                    } else {
+                        null
+                    }
+
                 segments.add(
                     TripSegment(
                         type = segmentType,
@@ -261,6 +270,7 @@ class ClusteringAlgorithm(
                         clusterId = clusterId,
                         timestamp = metadata.timestamp,
                         order = order++,
+                        photoAspectRatio = photoAspectRatio,
                     ),
                 )
             }

--- a/app/src/main/java/com/routesnap/app/domain/model/Models.kt
+++ b/app/src/main/java/com/routesnap/app/domain/model/Models.kt
@@ -72,12 +72,13 @@ data class ZoomRect(
          * Default start/end rect pairs that reproduce the old 4-direction Ken Burns
          * (scale 1.15→1.5, ±0.06 NDC pan). Derived analytically from the matrix math.
          */
-        private val DEFAULTS = listOf(
-            Pair(ZoomRect(0.09f, 0.09f, 0.96f, 0.96f), ZoomRect(0.15f, 0.15f, 0.81f, 0.81f)), // TL→BR
-            Pair(ZoomRect(0.04f, 0.09f, 0.91f, 0.96f), ZoomRect(0.19f, 0.15f, 0.85f, 0.81f)), // TR→BL
-            Pair(ZoomRect(0.09f, 0.04f, 0.96f, 0.91f), ZoomRect(0.15f, 0.19f, 0.81f, 0.85f)), // BL→TR
-            Pair(ZoomRect(0.04f, 0.04f, 0.91f, 0.91f), ZoomRect(0.19f, 0.19f, 0.85f, 0.85f)), // BR→TL
-        )
+        private val DEFAULTS =
+            listOf(
+                Pair(ZoomRect(0.09f, 0.09f, 0.96f, 0.96f), ZoomRect(0.15f, 0.15f, 0.81f, 0.81f)), // TL→BR
+                Pair(ZoomRect(0.04f, 0.09f, 0.91f, 0.96f), ZoomRect(0.19f, 0.15f, 0.85f, 0.81f)), // TR→BL
+                Pair(ZoomRect(0.09f, 0.04f, 0.96f, 0.91f), ZoomRect(0.15f, 0.19f, 0.81f, 0.85f)), // BL→TR
+                Pair(ZoomRect(0.04f, 0.04f, 0.91f, 0.91f), ZoomRect(0.19f, 0.19f, 0.85f, 0.85f)), // BR→TL
+            )
 
         fun defaultPair(index: Int): Pair<ZoomRect, ZoomRect> = DEFAULTS[index % DEFAULTS.size]
     }

--- a/app/src/main/java/com/routesnap/app/domain/model/Models.kt
+++ b/app/src/main/java/com/routesnap/app/domain/model/Models.kt
@@ -57,6 +57,17 @@ enum class TransitionType(
 }
 
 /**
+ * Normalized rectangle (0–1 coordinates) used as the Ken Burns end frame.
+ * Starting frame is always the full photo.
+ */
+data class ZoomRect(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float,
+)
+
+/**
  * Represents a single segment in the trip video timeline
  */
 data class TripSegment(
@@ -74,6 +85,9 @@ data class TripSegment(
     val order: Int = 0,
     val transitionType: TransitionType? = null,
     val transitionDurationMs: Long? = null,
+    val photoAspectRatio: Float? = null,
+    val zoomRect: ZoomRect? = null,
+    val isReviewed: Boolean = false,
 )
 
 /**

--- a/app/src/main/java/com/routesnap/app/domain/model/Models.kt
+++ b/app/src/main/java/com/routesnap/app/domain/model/Models.kt
@@ -86,7 +86,8 @@ data class TripSegment(
     val transitionType: TransitionType? = null,
     val transitionDurationMs: Long? = null,
     val photoAspectRatio: Float? = null,
-    val zoomRect: ZoomRect? = null,
+    val startZoomRect: ZoomRect? = null,
+    val endZoomRect: ZoomRect? = null,
     val isReviewed: Boolean = false,
 )
 

--- a/app/src/main/java/com/routesnap/app/domain/model/Models.kt
+++ b/app/src/main/java/com/routesnap/app/domain/model/Models.kt
@@ -69,15 +69,16 @@ data class ZoomRect(
         val FULL = ZoomRect(0f, 0f, 1f, 1f)
 
         /**
-         * Default start/end rect pairs that reproduce the old 4-direction Ken Burns
-         * (scale 1.15→1.5, ±0.06 NDC pan). Derived analytically from the matrix math.
+         * Default start/end rect pairs reproducing the old 4-direction Ken Burns
+         * (scale 1.15→1.5, ±0.06 NDC pan). y-values differ from x-values because
+         * Media3's GL pipeline flips the y-axis (ty = +cy*scale, not -cy*scale).
          */
         private val DEFAULTS =
             listOf(
-                Pair(ZoomRect(0.09f, 0.09f, 0.96f, 0.96f), ZoomRect(0.15f, 0.15f, 0.81f, 0.81f)), // TL→BR
-                Pair(ZoomRect(0.04f, 0.09f, 0.91f, 0.96f), ZoomRect(0.19f, 0.15f, 0.85f, 0.81f)), // TR→BL
-                Pair(ZoomRect(0.09f, 0.04f, 0.96f, 0.91f), ZoomRect(0.15f, 0.19f, 0.81f, 0.85f)), // BL→TR
-                Pair(ZoomRect(0.04f, 0.04f, 0.91f, 0.91f), ZoomRect(0.19f, 0.19f, 0.85f, 0.85f)), // BR→TL
+                Pair(ZoomRect(0.09f, 0.04f, 0.96f, 0.91f), ZoomRect(0.15f, 0.19f, 0.81f, 0.85f)), // TL→BR
+                Pair(ZoomRect(0.04f, 0.04f, 0.91f, 0.91f), ZoomRect(0.19f, 0.19f, 0.85f, 0.85f)), // TR→BL
+                Pair(ZoomRect(0.09f, 0.09f, 0.96f, 0.96f), ZoomRect(0.15f, 0.15f, 0.81f, 0.81f)), // BL→TR
+                Pair(ZoomRect(0.04f, 0.09f, 0.91f, 0.96f), ZoomRect(0.19f, 0.15f, 0.85f, 0.81f)), // BR→TL
             )
 
         fun defaultPair(index: Int): Pair<ZoomRect, ZoomRect> = DEFAULTS[index % DEFAULTS.size]

--- a/app/src/main/java/com/routesnap/app/domain/model/Models.kt
+++ b/app/src/main/java/com/routesnap/app/domain/model/Models.kt
@@ -57,15 +57,31 @@ enum class TransitionType(
 }
 
 /**
- * Normalized rectangle (0–1 coordinates) used as the Ken Burns end frame.
- * Starting frame is always the full photo.
+ * Normalized rectangle (0–1 coordinates) used as Ken Burns start/end frames.
  */
 data class ZoomRect(
     val left: Float,
     val top: Float,
     val right: Float,
     val bottom: Float,
-)
+) {
+    companion object {
+        val FULL = ZoomRect(0f, 0f, 1f, 1f)
+
+        /**
+         * Default start/end rect pairs that reproduce the old 4-direction Ken Burns
+         * (scale 1.15→1.5, ±0.06 NDC pan). Derived analytically from the matrix math.
+         */
+        private val DEFAULTS = listOf(
+            Pair(ZoomRect(0.09f, 0.09f, 0.96f, 0.96f), ZoomRect(0.15f, 0.15f, 0.81f, 0.81f)), // TL→BR
+            Pair(ZoomRect(0.04f, 0.09f, 0.91f, 0.96f), ZoomRect(0.19f, 0.15f, 0.85f, 0.81f)), // TR→BL
+            Pair(ZoomRect(0.09f, 0.04f, 0.96f, 0.91f), ZoomRect(0.15f, 0.19f, 0.81f, 0.85f)), // BL→TR
+            Pair(ZoomRect(0.04f, 0.04f, 0.91f, 0.91f), ZoomRect(0.19f, 0.19f, 0.85f, 0.85f)), // BR→TL
+        )
+
+        fun defaultPair(index: Int): Pair<ZoomRect, ZoomRect> = DEFAULTS[index % DEFAULTS.size]
+    }
+}
 
 /**
  * Represents a single segment in the trip video timeline

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -185,9 +185,9 @@ class RenderManager
             val uri = requireNotNull(segment.uri)
             val baseDuration = if (segment.durationMs > 0) segment.durationMs else 5000L
             val duration =
-                if (segment.zoomRect != null) {
-                    val rectW = segment.zoomRect.right - segment.zoomRect.left
-                    val rectH = segment.zoomRect.bottom - segment.zoomRect.top
+                if (segment.endZoomRect != null) {
+                    val rectW = segment.endZoomRect.right - segment.endZoomRect.left
+                    val rectH = segment.endZoomRect.bottom - segment.endZoomRect.top
                     val area = rectW * rectH
                     if (area > 0f) (baseDuration / area).toLong().coerceAtMost(12000L) else baseDuration
                 } else {
@@ -211,8 +211,9 @@ class RenderManager
                         add(FadeRgbMatrix(durationUs, headUs, fadeDurationUs, transition.type))
                     }
                     when {
-                        segment.zoomRect != null -> {
-                            add(kenBurnsZoomToRect(segment.zoomRect, duration))
+                        segment.endZoomRect != null -> {
+                            val start = segment.startZoomRect ?: ZoomRect(0f, 0f, 1f, 1f)
+                            add(kenBurnsZoomToRect(start, segment.endZoomRect, duration))
                         }
 
                         isLandscape -> {
@@ -342,30 +343,33 @@ class RenderManager
         }
 
         /**
-         * Ken Burns zoom from the full photo to a user-defined rect.
-         * zoomRect uses normalized 0–1 coordinates; scale is capped at 8× for safety.
+         * Ken Burns interpolation from startRect to endRect.
+         * Rects use normalized 0–1 coordinates over the photo; scale capped at 8×.
          */
         private fun kenBurnsZoomToRect(
-            zoomRect: ZoomRect,
+            startRect: ZoomRect,
+            endRect: ZoomRect,
             durationMs: Long,
         ): MatrixTransformation {
             val durationUs = durationMs * 1000L
             var startUs = -1L
-            val rectW = (zoomRect.right - zoomRect.left).coerceAtLeast(0.05f)
-            val rectH = (zoomRect.bottom - zoomRect.top).coerceAtLeast(0.05f)
-            val endScale = (1f / minOf(rectW, rectH)).coerceIn(1f, 8f)
-            // Rect center in NDC space (-1..1), y-axis pointing up
-            val cx = (zoomRect.left + zoomRect.right) - 1f
-            val cy = 1f - (zoomRect.top + zoomRect.bottom)
             return MatrixTransformation { presentationTimeUs ->
                 if (startUs < 0L) startUs = presentationTimeUs
                 val progress = ((presentationTimeUs - startUs).toFloat() / durationUs).coerceIn(0f, 1f)
-                val scale = 1f + (endScale - 1f) * progress
-                val tx = -cx * endScale * progress
-                val ty = -cy * endScale * progress
+                val rect = ZoomRect(
+                    left = startRect.left + (endRect.left - startRect.left) * progress,
+                    top = startRect.top + (endRect.top - startRect.top) * progress,
+                    right = startRect.right + (endRect.right - startRect.right) * progress,
+                    bottom = startRect.bottom + (endRect.bottom - startRect.bottom) * progress,
+                )
+                val rectW = (rect.right - rect.left).coerceAtLeast(0.05f)
+                val rectH = (rect.bottom - rect.top).coerceAtLeast(0.05f)
+                val scale = (1f / minOf(rectW, rectH)).coerceIn(1f, 8f)
+                val cx = (rect.left + rect.right) - 1f
+                val cy = 1f - (rect.top + rect.bottom)
                 android.graphics.Matrix().apply {
                     setScale(scale, scale)
-                    postTranslate(tx, ty)
+                    postTranslate(-cx * scale, -cy * scale)
                 }
             }
         }

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -295,7 +295,6 @@ class RenderManager
 
         private fun portraitPresentation(): Presentation = Presentation.createForWidthAndHeight(1080, 1920, Presentation.LAYOUT_SCALE_TO_FIT)
 
-
         /**
          * Horizontal pan for landscape photos. Scales so height fills the portrait frame,
          * then slides left↔right across the overflowing width. Direction alternates by index.
@@ -430,7 +429,6 @@ class RenderManager
             transformer = null
             _renderState.value = RenderState.Cancelled
         }
-
 
         /**
          * RgbMatrix-based fade transition. getMatrix() is called per-frame by Media3,

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -184,15 +184,14 @@ class RenderManager
         ): EditedMediaItem {
             val uri = requireNotNull(segment.uri)
             val baseDuration = if (segment.durationMs > 0) segment.durationMs else 5000L
-            val duration = when {
-                segment.zoomRect != null -> {
+            val duration =
+                if (segment.zoomRect != null) {
                     val area = (segment.zoomRect.right - segment.zoomRect.left) *
                         (segment.zoomRect.bottom - segment.zoomRect.top)
-                    if (area > 0f) (baseDuration / area).toLong().coerceAtMost(12000L)
-                    else baseDuration
+                    if (area > 0f) (baseDuration / area).toLong().coerceAtMost(12000L) else baseDuration
+                } else {
+                    baseDuration
                 }
-                else -> baseDuration
-            }
             android.util.Log.d("RenderManager", "PHOTO duration: $duration ms aspect: ${segment.photoAspectRatio} zoomRect: ${segment.zoomRect}")
             val mediaItem =
                 MediaItem
@@ -211,12 +210,17 @@ class RenderManager
                         add(FadeRgbMatrix(durationUs, headUs, fadeDurationUs, transition.type))
                     }
                     when {
-                        segment.zoomRect != null ->
+                        segment.zoomRect != null -> {
                             add(kenBurnsZoomToRect(segment.zoomRect, duration))
-                        isLandscape ->
+                        }
+
+                        isLandscape -> {
                             add(kenBurnsPanHorizontal(duration, photoIndex, segment.photoAspectRatio!!))
-                        else ->
+                        }
+
+                        else -> {
                             add(kenBurnsZoom(duration, photoIndex))
+                        }
                     }
                 }
             return EditedMediaItem

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -367,7 +367,7 @@ class RenderManager
                 val rectH = (rect.bottom - rect.top).coerceAtLeast(0.05f)
                 val scale = (1f / minOf(rectW, rectH)).coerceIn(1f, 8f)
                 val cx = (rect.left + rect.right) - 1f
-                val cy = 1f - (rect.top + rect.bottom)
+                val cy = (rect.top + rect.bottom) - 1f
                 android.graphics.Matrix().apply {
                     setScale(scale, scale)
                     postTranslate(-cx * scale, -cy * scale)

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -193,7 +193,7 @@ class RenderManager
                 } else {
                     baseDuration
                 }
-            android.util.Log.d("RenderManager", "PHOTO duration: $duration ms aspect: ${segment.photoAspectRatio} zoomRect: ${segment.zoomRect}")
+            android.util.Log.d("RenderManager", "PHOTO duration: $duration ms aspect: ${segment.photoAspectRatio} endZoomRect: ${segment.endZoomRect}")
             val mediaItem =
                 MediaItem
                     .Builder()

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -368,9 +368,11 @@ class RenderManager
                 val scale = (1f / minOf(rectW, rectH)).coerceIn(1f, 8f)
                 val cx = (rect.left + rect.right) - 1f
                 val cy = (rect.top + rect.bottom) - 1f
+                // tx: negative cx → shows right content (x-axis matches Android y-down)
+                // ty: positive cy → shows bottom content (y-axis is flipped in Media3's GL pipeline)
                 android.graphics.Matrix().apply {
                     setScale(scale, scale)
-                    postTranslate(-cx * scale, -cy * scale)
+                    postTranslate(-cx * scale, cy * scale)
                 }
             }
         }

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -186,8 +186,9 @@ class RenderManager
             val baseDuration = if (segment.durationMs > 0) segment.durationMs else 5000L
             val duration =
                 if (segment.zoomRect != null) {
-                    val area = (segment.zoomRect.right - segment.zoomRect.left) *
-                        (segment.zoomRect.bottom - segment.zoomRect.top)
+                    val rectW = segment.zoomRect.right - segment.zoomRect.left
+                    val rectH = segment.zoomRect.bottom - segment.zoomRect.top
+                    val area = rectW * rectH
                     if (area > 0f) (baseDuration / area).toLong().coerceAtMost(12000L) else baseDuration
                 } else {
                     baseDuration

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -295,27 +295,6 @@ class RenderManager
 
         private fun portraitPresentation(): Presentation = Presentation.createForWidthAndHeight(1080, 1920, Presentation.LAYOUT_SCALE_TO_FIT)
 
-        private fun kenBurnsZoom(
-            durationMs: Long,
-            index: Int,
-        ): MatrixTransformation {
-            val durationUs = durationMs * 1000L
-            var startUs = -1L
-            val pan = PAN_DIRECTIONS[index % PAN_DIRECTIONS.size]
-            return MatrixTransformation { presentationTimeUs ->
-                if (startUs < 0L) startUs = presentationTimeUs
-                val progress = ((presentationTimeUs - startUs).toFloat() / durationUs).coerceIn(0f, 1f)
-                // Scale 1.15→1.5: at minimum scale 1.15 we have 0.15 extra per side,
-                // which always exceeds the ±0.06 translation — no black edges possible.
-                val scale = 1.15f + 0.35f * progress
-                val tx = pan[0] + (pan[2] - pan[0]) * progress
-                val ty = pan[1] + (pan[3] - pan[1]) * progress
-                android.graphics.Matrix().apply {
-                    setScale(scale, scale)
-                    postTranslate(tx, ty)
-                }
-            }
-        }
 
         /**
          * Horizontal pan for landscape photos. Scales so height fills the portrait frame,
@@ -452,17 +431,6 @@ class RenderManager
             _renderState.value = RenderState.Cancelled
         }
 
-        companion object {
-            // [startX, startY, endX, endY] in NDC units [-1,1]. Values ±0.06 stay within
-            // the 0.1 extra margin that the minimum scale of 1.1 provides on each side.
-            private val PAN_DIRECTIONS =
-                arrayOf(
-                    floatArrayOf(-0.06f, -0.06f, 0.06f, 0.06f), // TL→BR
-                    floatArrayOf(0.06f, -0.06f, -0.06f, 0.06f), // TR→BL
-                    floatArrayOf(-0.06f, 0.06f, 0.06f, -0.06f), // BL→TR
-                    floatArrayOf(0.06f, 0.06f, -0.06f, -0.06f), // BR→TL
-                )
-        }
 
         /**
          * RgbMatrix-based fade transition. getMatrix() is called per-frame by Media3,

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -26,6 +26,7 @@ import com.routesnap.app.domain.model.TemplatePreset
 import com.routesnap.app.domain.model.TransitionType
 import com.routesnap.app.domain.model.TripManifest
 import com.routesnap.app.domain.model.TripSegment
+import com.routesnap.app.domain.model.ZoomRect
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
@@ -157,7 +158,7 @@ class RenderManager
                     val transition = effectiveTransition(segment, trip)
                     when (segment.type) {
                         SegmentType.PHOTO -> {
-                            buildPhotoSegment(uri, segment.durationMs, photoIndex, transition)
+                            buildPhotoSegment(segment, photoIndex, transition)
                                 .also { photoIndex++ }
                         }
 
@@ -177,32 +178,46 @@ class RenderManager
         }
 
         private fun buildPhotoSegment(
-            uri: Uri,
-            durationMs: Long,
+            segment: TripSegment,
             photoIndex: Int,
             transition: TransitionParams,
         ): EditedMediaItem {
-            val duration = if (durationMs > 0) durationMs else 5000L
-            android.util.Log.d("RenderManager", "PHOTO duration: $duration ms transition: ${transition.type} ${transition.durationMs}ms")
+            val uri = requireNotNull(segment.uri)
+            val baseDuration = if (segment.durationMs > 0) segment.durationMs else 5000L
+            val duration = when {
+                segment.zoomRect != null -> {
+                    val area = (segment.zoomRect.right - segment.zoomRect.left) *
+                        (segment.zoomRect.bottom - segment.zoomRect.top)
+                    if (area > 0f) (baseDuration / area).toLong().coerceAtMost(12000L)
+                    else baseDuration
+                }
+                else -> baseDuration
+            }
+            android.util.Log.d("RenderManager", "PHOTO duration: $duration ms aspect: ${segment.photoAspectRatio} zoomRect: ${segment.zoomRect}")
             val mediaItem =
                 MediaItem
                     .Builder()
                     .setUri(uri)
                     .setImageDurationMs(duration)
                     .build()
+            val isLandscape = (segment.photoAspectRatio ?: 1f) > 1f
             val videoEffects =
                 buildList {
                     add(portraitPresentation())
                     if (transition.type != TransitionType.NONE) {
                         val durationUs = duration * 1000L
                         val fadeDurationUs = transition.durationMs * 1000L
-                        // Tail fade on all photos; head fade skipped on the first photo so
-                        // the video starts clean. Max alpha 0.75 keeps the transition semi-
-                        // transparent (dissolve feel) rather than cutting to a solid colour.
                         val headUs = if (photoIndex == 0) 0L else fadeDurationUs
                         add(FadeRgbMatrix(durationUs, headUs, fadeDurationUs, transition.type))
                     }
-                    add(kenBurnsZoom(duration, photoIndex))
+                    when {
+                        segment.zoomRect != null ->
+                            add(kenBurnsZoomToRect(segment.zoomRect, duration))
+                        isLandscape ->
+                            add(kenBurnsPanHorizontal(duration, photoIndex, segment.photoAspectRatio!!))
+                        else ->
+                            add(kenBurnsZoom(duration, photoIndex))
+                    }
                 }
             return EditedMediaItem
                 .Builder(mediaItem)
@@ -289,6 +304,60 @@ class RenderManager
                 val scale = 1.15f + 0.35f * progress
                 val tx = pan[0] + (pan[2] - pan[0]) * progress
                 val ty = pan[1] + (pan[3] - pan[1]) * progress
+                android.graphics.Matrix().apply {
+                    setScale(scale, scale)
+                    postTranslate(tx, ty)
+                }
+            }
+        }
+
+        /**
+         * Horizontal pan for landscape photos. Scales so height fills the portrait frame,
+         * then slides left↔right across the overflowing width. Direction alternates by index.
+         */
+        private fun kenBurnsPanHorizontal(
+            durationMs: Long,
+            index: Int,
+            aspectRatio: Float,
+        ): MatrixTransformation {
+            val durationUs = durationMs * 1000L
+            var startUs = -1L
+            val panRange = (aspectRatio - 1f).coerceAtLeast(0f)
+            val startX = if (index % 2 == 0) -panRange else panRange
+            val endX = -startX
+            return MatrixTransformation { presentationTimeUs ->
+                if (startUs < 0L) startUs = presentationTimeUs
+                val progress = ((presentationTimeUs - startUs).toFloat() / durationUs).coerceIn(0f, 1f)
+                val tx = startX + (endX - startX) * progress
+                android.graphics.Matrix().apply {
+                    setScale(aspectRatio, aspectRatio)
+                    postTranslate(tx, 0f)
+                }
+            }
+        }
+
+        /**
+         * Ken Burns zoom from the full photo to a user-defined rect.
+         * zoomRect uses normalized 0–1 coordinates; scale is capped at 8× for safety.
+         */
+        private fun kenBurnsZoomToRect(
+            zoomRect: ZoomRect,
+            durationMs: Long,
+        ): MatrixTransformation {
+            val durationUs = durationMs * 1000L
+            var startUs = -1L
+            val rectW = (zoomRect.right - zoomRect.left).coerceAtLeast(0.05f)
+            val rectH = (zoomRect.bottom - zoomRect.top).coerceAtLeast(0.05f)
+            val endScale = (1f / minOf(rectW, rectH)).coerceIn(1f, 8f)
+            // Rect center in NDC space (-1..1), y-axis pointing up
+            val cx = (zoomRect.left + zoomRect.right) - 1f
+            val cy = 1f - (zoomRect.top + zoomRect.bottom)
+            return MatrixTransformation { presentationTimeUs ->
+                if (startUs < 0L) startUs = presentationTimeUs
+                val progress = ((presentationTimeUs - startUs).toFloat() / durationUs).coerceIn(0f, 1f)
+                val scale = 1f + (endScale - 1f) * progress
+                val tx = -cx * endScale * progress
+                val ty = -cy * endScale * progress
                 android.graphics.Matrix().apply {
                     setScale(scale, scale)
                     postTranslate(tx, ty)

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -211,17 +211,17 @@ class RenderManager
                         add(FadeRgbMatrix(durationUs, headUs, fadeDurationUs, transition.type))
                     }
                     when {
-                        segment.endZoomRect != null -> {
-                            val start = segment.startZoomRect ?: ZoomRect(0f, 0f, 1f, 1f)
-                            add(kenBurnsZoomToRect(start, segment.endZoomRect, duration))
-                        }
-
                         isLandscape -> {
                             add(kenBurnsPanHorizontal(duration, photoIndex, segment.photoAspectRatio!!))
                         }
 
                         else -> {
-                            add(kenBurnsZoom(duration, photoIndex))
+                            // Use stored rects (user-defined or default), falling back to
+                            // computed defaults if the segment predates this feature.
+                            val (defStart, defEnd) = ZoomRect.defaultPair(photoIndex)
+                            val start = segment.startZoomRect ?: defStart
+                            val end = segment.endZoomRect ?: defEnd
+                            add(kenBurnsZoomToRect(start, end, duration))
                         }
                     }
                 }
@@ -356,12 +356,13 @@ class RenderManager
             return MatrixTransformation { presentationTimeUs ->
                 if (startUs < 0L) startUs = presentationTimeUs
                 val progress = ((presentationTimeUs - startUs).toFloat() / durationUs).coerceIn(0f, 1f)
-                val rect = ZoomRect(
-                    left = startRect.left + (endRect.left - startRect.left) * progress,
-                    top = startRect.top + (endRect.top - startRect.top) * progress,
-                    right = startRect.right + (endRect.right - startRect.right) * progress,
-                    bottom = startRect.bottom + (endRect.bottom - startRect.bottom) * progress,
-                )
+                val rect =
+                    ZoomRect(
+                        left = startRect.left + (endRect.left - startRect.left) * progress,
+                        top = startRect.top + (endRect.top - startRect.top) * progress,
+                        right = startRect.right + (endRect.right - startRect.right) * progress,
+                        bottom = startRect.bottom + (endRect.bottom - startRect.bottom) * progress,
+                    )
                 val rectW = (rect.right - rect.left).coerceAtLeast(0.05f)
                 val rectH = (rect.bottom - rect.top).coerceAtLeast(0.05f)
                 val scale = (1f / minOf(rectW, rectH)).coerceIn(1f, 8f)

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
@@ -1,0 +1,300 @@
+package com.routesnap.app.ui.review
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBackIosNew
+import androidx.compose.material.icons.filled.ArrowForwardIos
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.routesnap.app.domain.model.ZoomRect
+import com.routesnap.app.ui.theme.RouteSnapTheme
+import kotlin.math.roundToInt
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+private val START_COLOR = Color(0xFF2196F3)
+private val END_COLOR = Color(0xFFFF9800)
+private const val HANDLE_DP = 14
+private const val MIN_RECT_FRAC = 0.1f
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PhotoReviewScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PhotoReviewViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.saveCurrentRects() }
+    }
+
+    RouteSnapTheme {
+        Scaffold(
+            modifier = modifier,
+            topBar = {
+                TopAppBar(
+                    title = {
+                        val index = uiState.currentIndex
+                        val total = uiState.segments.size
+                        Text("Photo ${index + 1} / $total")
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = {
+                            viewModel.saveCurrentRects()
+                            onNavigateBack()
+                        }) {
+                            Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = {
+                            viewModel.saveCurrentRects()
+                            onNavigateBack()
+                        }) {
+                            Icon(Icons.Default.Check, contentDescription = "Done")
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                        actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                )
+            },
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Legend
+                Row(
+                    modifier = Modifier.padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(Modifier.size(16.dp).background(START_COLOR))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Start", style = MaterialTheme.typography.bodySmall)
+                    Spacer(Modifier.width(16.dp))
+                    Box(Modifier.size(16.dp).background(END_COLOR))
+                    Spacer(Modifier.width(4.dp))
+                    Text("End", style = MaterialTheme.typography.bodySmall)
+                }
+
+                // Photo with rect overlays — takes up all remaining space
+                var imageSize by remember { mutableStateOf(IntSize.Zero) }
+
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .onSizeChanged { imageSize = it },
+                ) {
+                    uiState.current?.uri?.let { uri ->
+                        AsyncImage(
+                            model = uri,
+                            contentDescription = null,
+                            contentScale = ContentScale.Fit,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+
+                    if (imageSize != IntSize.Zero) {
+                        ZoomRectOverlay(
+                            rect = uiState.startRect,
+                            color = START_COLOR,
+                            containerSize = imageSize,
+                            onRectChange = viewModel::updateStartRect,
+                        )
+                        ZoomRectOverlay(
+                            rect = uiState.endRect,
+                            color = END_COLOR,
+                            containerSize = imageSize,
+                            onRectChange = viewModel::updateEndRect,
+                        )
+                    }
+                }
+
+                // Prev / Next navigation
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(64.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(
+                        onClick = { viewModel.navigateTo(uiState.currentIndex - 1) },
+                        enabled = uiState.hasPrev,
+                        modifier = Modifier.weight(1f).fillMaxSize(),
+                    ) {
+                        Icon(
+                            Icons.Default.ArrowBackIosNew,
+                            contentDescription = "Previous",
+                            modifier = Modifier.size(32.dp),
+                        )
+                    }
+                    IconButton(
+                        onClick = { viewModel.navigateTo(uiState.currentIndex + 1) },
+                        enabled = uiState.hasNext,
+                        modifier = Modifier.weight(1f).fillMaxSize(),
+                    ) {
+                        Icon(
+                            Icons.Default.ArrowForwardIos,
+                            contentDescription = "Next",
+                            modifier = Modifier.size(32.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ZoomRectOverlay(
+    rect: ZoomRect,
+    color: Color,
+    containerSize: IntSize,
+    onRectChange: (ZoomRect) -> Unit,
+) {
+    val density = LocalDensity.current
+    val handlePx = with(density) { HANDLE_DP.dp.toPx() }
+
+    val left = rect.left * containerSize.width
+    val top = rect.top * containerSize.height
+    val right = rect.right * containerSize.width
+    val bottom = rect.bottom * containerSize.height
+
+    // Body — drag to move entire rect
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
+            .size(
+                width = with(density) { (right - left).toDp() },
+                height = with(density) { (bottom - top).toDp() },
+            )
+            .border(2.dp, color)
+            .pointerInput(rect) {
+                detectDragGestures { _, drag ->
+                    val dx = drag.x / containerSize.width
+                    val dy = drag.y / containerSize.height
+                    val w = rect.right - rect.left
+                    val h = rect.bottom - rect.top
+                    val newL = (rect.left + dx).coerceIn(0f, 1f - w)
+                    val newT = (rect.top + dy).coerceIn(0f, 1f - h)
+                    onRectChange(ZoomRect(newL, newT, newL + w, newT + h))
+                }
+            },
+    )
+
+    // Corner handles
+    Handle(Offset(left, top), color, handlePx) { drag ->
+        onRectChange(ZoomRect(
+            left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
+            top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
+            right = rect.right, bottom = rect.bottom,
+        ))
+    }
+    Handle(Offset(right - handlePx, top), color, handlePx) { drag ->
+        onRectChange(ZoomRect(
+            left = rect.left, top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
+            right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
+            bottom = rect.bottom,
+        ))
+    }
+    Handle(Offset(left, bottom - handlePx), color, handlePx) { drag ->
+        onRectChange(ZoomRect(
+            left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
+            top = rect.top, right = rect.right,
+            bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
+        ))
+    }
+    Handle(Offset(right - handlePx, bottom - handlePx), color, handlePx) { drag ->
+        onRectChange(ZoomRect(
+            left = rect.left, top = rect.top,
+            right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
+            bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
+        ))
+    }
+
+    // Edge handles
+    val midX = (left + right) / 2 - handlePx / 2
+    val midY = (top + bottom) / 2 - handlePx / 2
+    Handle(Offset(midX, top), color, handlePx) { drag ->
+        onRectChange(rect.copy(top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC)))
+    }
+    Handle(Offset(midX, bottom - handlePx), color, handlePx) { drag ->
+        onRectChange(rect.copy(bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f)))
+    }
+    Handle(Offset(left, midY), color, handlePx) { drag ->
+        onRectChange(rect.copy(left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC)))
+    }
+    Handle(Offset(right - handlePx, midY), color, handlePx) { drag ->
+        onRectChange(rect.copy(right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f)))
+    }
+}
+
+@Composable
+private fun Handle(
+    position: Offset,
+    color: Color,
+    sizePx: Float,
+    onDrag: (Offset) -> Unit,
+) {
+    val density = LocalDensity.current
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(position.x.roundToInt(), position.y.roundToInt()) }
+            .size(with(density) { sizePx.toDp() })
+            .clip(RectangleShape)
+            .background(color)
+            .pointerInput(Unit) {
+                detectDragGestures { _, drag -> onDrag(drag) }
+            },
+    )
+}

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
@@ -202,6 +202,10 @@ private fun ZoomRectOverlay(
     containerSize: IntSize,
     onRectChange: (ZoomRect) -> Unit,
 ) {
+    // rememberUpdatedState: drag lambdas always read the latest rect/callback
+    // without restarting the gesture detector on every state change.
+    val currentRect by androidx.compose.runtime.rememberUpdatedState(rect)
+    val currentOnChange by androidx.compose.runtime.rememberUpdatedState(onRectChange)
     val density = LocalDensity.current
     val handlePx = with(density) { HANDLE_DP.dp.toPx() }
 
@@ -212,7 +216,6 @@ private fun ZoomRectOverlay(
     val midX = (left + right) / 2 - handlePx / 2
     val midY = (top + bottom) / 2 - handlePx / 2
 
-    // Single top-level Box wraps all emissions (rect border + handles)
     Box(modifier = Modifier.fillMaxSize()) {
         // Body — drag to move entire rect
         Box(
@@ -223,60 +226,70 @@ private fun ZoomRectOverlay(
                     height = with(density) { (bottom - top).toDp() },
                 )
                 .border(2.dp, color)
-                .pointerInput(rect) {
+                // pointerInput(Unit) — never restarts; reads currentRect via rememberUpdatedState
+                .pointerInput(Unit) {
                     detectDragGestures { _, drag ->
+                        val r = currentRect
                         val dx = drag.x / containerSize.width
                         val dy = drag.y / containerSize.height
-                        val w = rect.right - rect.left
-                        val h = rect.bottom - rect.top
-                        val newL = (rect.left + dx).coerceIn(0f, 1f - w)
-                        val newT = (rect.top + dy).coerceIn(0f, 1f - h)
-                        onRectChange(ZoomRect(newL, newT, newL + w, newT + h))
+                        val w = r.right - r.left
+                        val h = r.bottom - r.top
+                        val newL = (r.left + dx).coerceIn(0f, 1f - w)
+                        val newT = (r.top + dy).coerceIn(0f, 1f - h)
+                        currentOnChange(ZoomRect(newL, newT, newL + w, newT + h))
                     }
                 },
         )
         // Corner handles
         Handle(Offset(left, top), color, handlePx) { drag ->
-            onRectChange(ZoomRect(
-                left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
-                top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
-                right = rect.right, bottom = rect.bottom,
+            val r = currentRect
+            currentOnChange(ZoomRect(
+                left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC),
+                top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC),
+                right = r.right, bottom = r.bottom,
             ))
         }
         Handle(Offset(right - handlePx, top), color, handlePx) { drag ->
-            onRectChange(ZoomRect(
-                left = rect.left,
-                top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
-                right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
-                bottom = rect.bottom,
+            val r = currentRect
+            currentOnChange(ZoomRect(
+                left = r.left,
+                top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC),
+                right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f),
+                bottom = r.bottom,
             ))
         }
         Handle(Offset(left, bottom - handlePx), color, handlePx) { drag ->
-            onRectChange(ZoomRect(
-                left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
-                top = rect.top, right = rect.right,
-                bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
+            val r = currentRect
+            currentOnChange(ZoomRect(
+                left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC),
+                top = r.top, right = r.right,
+                bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f),
             ))
         }
         Handle(Offset(right - handlePx, bottom - handlePx), color, handlePx) { drag ->
-            onRectChange(ZoomRect(
-                left = rect.left, top = rect.top,
-                right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
-                bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
+            val r = currentRect
+            currentOnChange(ZoomRect(
+                left = r.left, top = r.top,
+                right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f),
+                bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f),
             ))
         }
         // Edge handles
         Handle(Offset(midX, top), color, handlePx) { drag ->
-            onRectChange(rect.copy(top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC)))
+            val r = currentRect
+            currentOnChange(r.copy(top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC)))
         }
         Handle(Offset(midX, bottom - handlePx), color, handlePx) { drag ->
-            onRectChange(rect.copy(bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f)))
+            val r = currentRect
+            currentOnChange(r.copy(bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f)))
         }
         Handle(Offset(left, midY), color, handlePx) { drag ->
-            onRectChange(rect.copy(left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC)))
+            val r = currentRect
+            currentOnChange(r.copy(left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC)))
         }
         Handle(Offset(right - handlePx, midY), color, handlePx) { drag ->
-            onRectChange(rect.copy(right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f)))
+            val r = currentRect
+            currentOnChange(r.copy(right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f)))
         }
     }
 }
@@ -288,6 +301,9 @@ private fun Handle(
     sizePx: Float,
     onDrag: (Offset) -> Unit,
 ) {
+    // rememberUpdatedState ensures the latest onDrag lambda is always called,
+    // even though pointerInput(Unit) never restarts the gesture detector.
+    val currentOnDrag by androidx.compose.runtime.rememberUpdatedState(onDrag)
     val density = LocalDensity.current
     Box(
         modifier = Modifier
@@ -296,7 +312,7 @@ private fun Handle(
             .clip(RectangleShape)
             .background(color)
             .pointerInput(Unit) {
-                detectDragGestures { _, drag -> onDrag(drag) }
+                detectDragGestures { _, drag -> currentOnDrag(drag) }
             },
     )
 }

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
@@ -145,7 +145,7 @@ fun PhotoReviewScreen(
                         AsyncImage(
                             model = uri,
                             contentDescription = null,
-                            contentScale = ContentScale.FillBounds,
+                            contentScale = ContentScale.Fit,
                             modifier = Modifier.fillMaxSize(),
                         )
                     }

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -134,15 +135,17 @@ fun PhotoReviewScreen(
                 Box(
                     modifier =
                         Modifier
-                            .weight(1f)
                             .fillMaxWidth()
+                            // Lock to 9:16 so photo fills the box without letterboxing.
+                            // This ensures ZoomRect 0-1 coords match renderer coords exactly.
+                            .aspectRatio(9f / 16f)
                             .onSizeChanged { imageSize = it },
                 ) {
                     uiState.current?.uri?.let { uri ->
                         AsyncImage(
                             model = uri,
                             contentDescription = null,
-                            contentScale = ContentScale.Fit,
+                            contentScale = ContentScale.FillBounds,
                             modifier = Modifier.fillMaxSize(),
                         )
                     }

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,9 +52,6 @@ import coil.compose.AsyncImage
 import com.routesnap.app.domain.model.ZoomRect
 import com.routesnap.app.ui.theme.RouteSnapTheme
 import kotlin.math.roundToInt
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 
 private val START_COLOR = Color(0xFF2196F3)
 private val END_COLOR = Color(0xFFFF9800)
@@ -97,19 +97,21 @@ fun PhotoReviewScreen(
                             Icon(Icons.Default.Check, contentDescription = "Done")
                         }
                     },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = MaterialTheme.colorScheme.onPrimary,
-                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                        actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+                    colors =
+                        TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                            navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                            actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
                 )
             },
         ) { padding ->
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 // Legend
@@ -130,10 +132,11 @@ fun PhotoReviewScreen(
                 var imageSize by remember { mutableStateOf(IntSize.Zero) }
 
                 Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth()
-                        .onSizeChanged { imageSize = it },
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .onSizeChanged { imageSize = it },
                 ) {
                     uiState.current?.uri?.let { uri ->
                         AsyncImage(
@@ -162,9 +165,10 @@ fun PhotoReviewScreen(
 
                 // Prev / Next navigation
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(64.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(64.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     IconButton(
@@ -219,60 +223,71 @@ private fun ZoomRectOverlay(
     Box(modifier = Modifier.fillMaxSize()) {
         // Body — drag to move entire rect
         Box(
-            modifier = Modifier
-                .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
-                .size(
-                    width = with(density) { (right - left).toDp() },
-                    height = with(density) { (bottom - top).toDp() },
-                )
-                .border(2.dp, color)
-                // pointerInput(Unit) — never restarts; reads currentRect via rememberUpdatedState
-                .pointerInput(Unit) {
-                    detectDragGestures { _, drag ->
-                        val r = currentRect
-                        val dx = drag.x / containerSize.width
-                        val dy = drag.y / containerSize.height
-                        val w = r.right - r.left
-                        val h = r.bottom - r.top
-                        val newL = (r.left + dx).coerceIn(0f, 1f - w)
-                        val newT = (r.top + dy).coerceIn(0f, 1f - h)
-                        currentOnChange(ZoomRect(newL, newT, newL + w, newT + h))
-                    }
-                },
+            modifier =
+                Modifier
+                    .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
+                    .size(
+                        width = with(density) { (right - left).toDp() },
+                        height = with(density) { (bottom - top).toDp() },
+                    ).border(2.dp, color)
+                    // pointerInput(Unit) — never restarts; reads currentRect via rememberUpdatedState
+                    .pointerInput(Unit) {
+                        detectDragGestures { _, drag ->
+                            val r = currentRect
+                            val dx = drag.x / containerSize.width
+                            val dy = drag.y / containerSize.height
+                            val w = r.right - r.left
+                            val h = r.bottom - r.top
+                            val newL = (r.left + dx).coerceIn(0f, 1f - w)
+                            val newT = (r.top + dy).coerceIn(0f, 1f - h)
+                            currentOnChange(ZoomRect(newL, newT, newL + w, newT + h))
+                        }
+                    },
         )
         // Corner handles
         Handle(Offset(left, top), color, handlePx) { drag ->
             val r = currentRect
-            currentOnChange(ZoomRect(
-                left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC),
-                top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC),
-                right = r.right, bottom = r.bottom,
-            ))
+            currentOnChange(
+                ZoomRect(
+                    left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC),
+                    top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC),
+                    right = r.right,
+                    bottom = r.bottom,
+                ),
+            )
         }
         Handle(Offset(right - handlePx, top), color, handlePx) { drag ->
             val r = currentRect
-            currentOnChange(ZoomRect(
-                left = r.left,
-                top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC),
-                right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f),
-                bottom = r.bottom,
-            ))
+            currentOnChange(
+                ZoomRect(
+                    left = r.left,
+                    top = (r.top + drag.y / containerSize.height).coerceIn(0f, r.bottom - MIN_RECT_FRAC),
+                    right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f),
+                    bottom = r.bottom,
+                ),
+            )
         }
         Handle(Offset(left, bottom - handlePx), color, handlePx) { drag ->
             val r = currentRect
-            currentOnChange(ZoomRect(
-                left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC),
-                top = r.top, right = r.right,
-                bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f),
-            ))
+            currentOnChange(
+                ZoomRect(
+                    left = (r.left + drag.x / containerSize.width).coerceIn(0f, r.right - MIN_RECT_FRAC),
+                    top = r.top,
+                    right = r.right,
+                    bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f),
+                ),
+            )
         }
         Handle(Offset(right - handlePx, bottom - handlePx), color, handlePx) { drag ->
             val r = currentRect
-            currentOnChange(ZoomRect(
-                left = r.left, top = r.top,
-                right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f),
-                bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f),
-            ))
+            currentOnChange(
+                ZoomRect(
+                    left = r.left,
+                    top = r.top,
+                    right = (r.right + drag.x / containerSize.width).coerceIn(r.left + MIN_RECT_FRAC, 1f),
+                    bottom = (r.bottom + drag.y / containerSize.height).coerceIn(r.top + MIN_RECT_FRAC, 1f),
+                ),
+            )
         }
         // Edge handles
         Handle(Offset(midX, top), color, handlePx) { drag ->
@@ -306,13 +321,14 @@ private fun Handle(
     val currentOnDrag by androidx.compose.runtime.rememberUpdatedState(onDrag)
     val density = LocalDensity.current
     Box(
-        modifier = Modifier
-            .offset { IntOffset(position.x.roundToInt(), position.y.roundToInt()) }
-            .size(with(density) { sizePx.toDp() })
-            .clip(RectangleShape)
-            .background(color)
-            .pointerInput(Unit) {
-                detectDragGestures { _, drag -> currentOnDrag(drag) }
-            },
+        modifier =
+            Modifier
+                .offset { IntOffset(position.x.roundToInt(), position.y.roundToInt()) }
+                .size(with(density) { sizePx.toDp() })
+                .clip(RectangleShape)
+                .background(color)
+                .pointerInput(Unit) {
+                    detectDragGestures { _, drag -> currentOnDrag(drag) }
+                },
     )
 }

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewScreen.kt
@@ -209,73 +209,75 @@ private fun ZoomRectOverlay(
     val top = rect.top * containerSize.height
     val right = rect.right * containerSize.width
     val bottom = rect.bottom * containerSize.height
-
-    // Body — drag to move entire rect
-    Box(
-        modifier = Modifier
-            .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
-            .size(
-                width = with(density) { (right - left).toDp() },
-                height = with(density) { (bottom - top).toDp() },
-            )
-            .border(2.dp, color)
-            .pointerInput(rect) {
-                detectDragGestures { _, drag ->
-                    val dx = drag.x / containerSize.width
-                    val dy = drag.y / containerSize.height
-                    val w = rect.right - rect.left
-                    val h = rect.bottom - rect.top
-                    val newL = (rect.left + dx).coerceIn(0f, 1f - w)
-                    val newT = (rect.top + dy).coerceIn(0f, 1f - h)
-                    onRectChange(ZoomRect(newL, newT, newL + w, newT + h))
-                }
-            },
-    )
-
-    // Corner handles
-    Handle(Offset(left, top), color, handlePx) { drag ->
-        onRectChange(ZoomRect(
-            left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
-            top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
-            right = rect.right, bottom = rect.bottom,
-        ))
-    }
-    Handle(Offset(right - handlePx, top), color, handlePx) { drag ->
-        onRectChange(ZoomRect(
-            left = rect.left, top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
-            right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
-            bottom = rect.bottom,
-        ))
-    }
-    Handle(Offset(left, bottom - handlePx), color, handlePx) { drag ->
-        onRectChange(ZoomRect(
-            left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
-            top = rect.top, right = rect.right,
-            bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
-        ))
-    }
-    Handle(Offset(right - handlePx, bottom - handlePx), color, handlePx) { drag ->
-        onRectChange(ZoomRect(
-            left = rect.left, top = rect.top,
-            right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
-            bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
-        ))
-    }
-
-    // Edge handles
     val midX = (left + right) / 2 - handlePx / 2
     val midY = (top + bottom) / 2 - handlePx / 2
-    Handle(Offset(midX, top), color, handlePx) { drag ->
-        onRectChange(rect.copy(top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC)))
-    }
-    Handle(Offset(midX, bottom - handlePx), color, handlePx) { drag ->
-        onRectChange(rect.copy(bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f)))
-    }
-    Handle(Offset(left, midY), color, handlePx) { drag ->
-        onRectChange(rect.copy(left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC)))
-    }
-    Handle(Offset(right - handlePx, midY), color, handlePx) { drag ->
-        onRectChange(rect.copy(right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f)))
+
+    // Single top-level Box wraps all emissions (rect border + handles)
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Body — drag to move entire rect
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
+                .size(
+                    width = with(density) { (right - left).toDp() },
+                    height = with(density) { (bottom - top).toDp() },
+                )
+                .border(2.dp, color)
+                .pointerInput(rect) {
+                    detectDragGestures { _, drag ->
+                        val dx = drag.x / containerSize.width
+                        val dy = drag.y / containerSize.height
+                        val w = rect.right - rect.left
+                        val h = rect.bottom - rect.top
+                        val newL = (rect.left + dx).coerceIn(0f, 1f - w)
+                        val newT = (rect.top + dy).coerceIn(0f, 1f - h)
+                        onRectChange(ZoomRect(newL, newT, newL + w, newT + h))
+                    }
+                },
+        )
+        // Corner handles
+        Handle(Offset(left, top), color, handlePx) { drag ->
+            onRectChange(ZoomRect(
+                left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
+                top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
+                right = rect.right, bottom = rect.bottom,
+            ))
+        }
+        Handle(Offset(right - handlePx, top), color, handlePx) { drag ->
+            onRectChange(ZoomRect(
+                left = rect.left,
+                top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC),
+                right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
+                bottom = rect.bottom,
+            ))
+        }
+        Handle(Offset(left, bottom - handlePx), color, handlePx) { drag ->
+            onRectChange(ZoomRect(
+                left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC),
+                top = rect.top, right = rect.right,
+                bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
+            ))
+        }
+        Handle(Offset(right - handlePx, bottom - handlePx), color, handlePx) { drag ->
+            onRectChange(ZoomRect(
+                left = rect.left, top = rect.top,
+                right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f),
+                bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f),
+            ))
+        }
+        // Edge handles
+        Handle(Offset(midX, top), color, handlePx) { drag ->
+            onRectChange(rect.copy(top = (rect.top + drag.y / containerSize.height).coerceIn(0f, rect.bottom - MIN_RECT_FRAC)))
+        }
+        Handle(Offset(midX, bottom - handlePx), color, handlePx) { drag ->
+            onRectChange(rect.copy(bottom = (rect.bottom + drag.y / containerSize.height).coerceIn(rect.top + MIN_RECT_FRAC, 1f)))
+        }
+        Handle(Offset(left, midY), color, handlePx) { drag ->
+            onRectChange(rect.copy(left = (rect.left + drag.x / containerSize.width).coerceIn(0f, rect.right - MIN_RECT_FRAC)))
+        }
+        Handle(Offset(right - handlePx, midY), color, handlePx) { drag ->
+            onRectChange(rect.copy(right = (rect.right + drag.x / containerSize.width).coerceIn(rect.left + MIN_RECT_FRAC, 1f)))
+        }
     }
 }
 

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewViewModel.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewViewModel.kt
@@ -98,5 +98,4 @@ class PhotoReviewViewModel
                 )
             }
         }
-
     }

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewViewModel.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewViewModel.kt
@@ -46,18 +46,22 @@ class PhotoReviewViewModel
             viewModelScope.launch {
                 val id = tripId ?: return@launch
                 val trip = tripRepository.getTripById(id) ?: return@launch
-                val photoSegments = trip.segments.filter {
-                    it.uri != null && it.type == com.routesnap.app.domain.model.SegmentType.PHOTO
-                }
-                val initialIndex = photoSegments.indexOfFirst { it.id == initialSegmentId }
-                    .coerceAtLeast(0)
+                val photoSegments =
+                    trip.segments.filter {
+                        it.uri != null && it.type == com.routesnap.app.domain.model.SegmentType.PHOTO
+                    }
+                val initialIndex =
+                    photoSegments
+                        .indexOfFirst { it.id == initialSegmentId }
+                        .coerceAtLeast(0)
                 val initial = photoSegments.getOrNull(initialIndex)
-                _uiState.value = PhotoReviewUiState(
-                    segments = photoSegments,
-                    currentIndex = initialIndex,
-                    startRect = initial?.startZoomRect ?: ZoomRect(0f, 0f, 1f, 1f),
-                    endRect = initial?.endZoomRect ?: defaultEndRect(initialIndex),
-                )
+                _uiState.value =
+                    PhotoReviewUiState(
+                        segments = photoSegments,
+                        currentIndex = initialIndex,
+                        startRect = initial?.startZoomRect ?: ZoomRect.defaultPair(initialIndex).first,
+                        endRect = initial?.endZoomRect ?: ZoomRect.defaultPair(initialIndex).second,
+                    )
             }
         }
 
@@ -65,11 +69,12 @@ class PhotoReviewViewModel
             saveCurrentRects()
             val state = _uiState.value
             val next = state.segments.getOrNull(index) ?: return
-            _uiState.value = state.copy(
-                currentIndex = index,
-                startRect = next.startZoomRect ?: ZoomRect(0f, 0f, 1f, 1f),
-                endRect = next.endZoomRect ?: defaultEndRect(index),
-            )
+            _uiState.value =
+                state.copy(
+                    currentIndex = index,
+                    startRect = next.startZoomRect ?: ZoomRect.defaultPair(index).first,
+                    endRect = next.endZoomRect ?: ZoomRect.defaultPair(index).second,
+                )
         }
 
         fun updateStartRect(rect: ZoomRect) {
@@ -94,13 +99,4 @@ class PhotoReviewViewModel
             }
         }
 
-        private fun defaultEndRect(index: Int): ZoomRect {
-            val presets = listOf(
-                ZoomRect(0.15f, 0.1f, 0.85f, 0.9f),
-                ZoomRect(0.05f, 0.05f, 0.65f, 0.95f),
-                ZoomRect(0.35f, 0.05f, 0.95f, 0.95f),
-                ZoomRect(0.1f, 0.15f, 0.9f, 0.85f),
-            )
-            return presets[index % presets.size]
-        }
     }

--- a/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewViewModel.kt
+++ b/app/src/main/java/com/routesnap/app/ui/review/PhotoReviewViewModel.kt
@@ -1,0 +1,106 @@
+package com.routesnap.app.ui.review
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.routesnap.app.data.repository.TripRepository
+import com.routesnap.app.domain.model.TripSegment
+import com.routesnap.app.domain.model.ZoomRect
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class PhotoReviewUiState(
+    val segments: List<TripSegment> = emptyList(),
+    val currentIndex: Int = 0,
+    val startRect: ZoomRect = ZoomRect(0f, 0f, 1f, 1f),
+    val endRect: ZoomRect = ZoomRect(0.15f, 0.1f, 0.85f, 0.9f),
+    val isSaving: Boolean = false,
+) {
+    val current: TripSegment? get() = segments.getOrNull(currentIndex)
+    val hasPrev: Boolean get() = currentIndex > 0
+    val hasNext: Boolean get() = currentIndex < segments.size - 1
+}
+
+@HiltViewModel
+class PhotoReviewViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+        private val tripRepository: TripRepository,
+    ) : ViewModel() {
+        private val tripId: String? = savedStateHandle["tripId"]
+        private val initialSegmentId: String? = savedStateHandle["segmentId"]
+
+        private val _uiState = MutableStateFlow(PhotoReviewUiState())
+        val uiState: StateFlow<PhotoReviewUiState> = _uiState.asStateFlow()
+
+        init {
+            loadSegments()
+        }
+
+        private fun loadSegments() {
+            viewModelScope.launch {
+                val id = tripId ?: return@launch
+                val trip = tripRepository.getTripById(id) ?: return@launch
+                val photoSegments = trip.segments.filter {
+                    it.uri != null && it.type == com.routesnap.app.domain.model.SegmentType.PHOTO
+                }
+                val initialIndex = photoSegments.indexOfFirst { it.id == initialSegmentId }
+                    .coerceAtLeast(0)
+                val initial = photoSegments.getOrNull(initialIndex)
+                _uiState.value = PhotoReviewUiState(
+                    segments = photoSegments,
+                    currentIndex = initialIndex,
+                    startRect = initial?.startZoomRect ?: ZoomRect(0f, 0f, 1f, 1f),
+                    endRect = initial?.endZoomRect ?: defaultEndRect(initialIndex),
+                )
+            }
+        }
+
+        fun navigateTo(index: Int) {
+            saveCurrentRects()
+            val state = _uiState.value
+            val next = state.segments.getOrNull(index) ?: return
+            _uiState.value = state.copy(
+                currentIndex = index,
+                startRect = next.startZoomRect ?: ZoomRect(0f, 0f, 1f, 1f),
+                endRect = next.endZoomRect ?: defaultEndRect(index),
+            )
+        }
+
+        fun updateStartRect(rect: ZoomRect) {
+            _uiState.value = _uiState.value.copy(startRect = rect)
+        }
+
+        fun updateEndRect(rect: ZoomRect) {
+            _uiState.value = _uiState.value.copy(endRect = rect)
+        }
+
+        fun saveCurrentRects() {
+            val state = _uiState.value
+            val segment = state.current ?: return
+            val id = tripId ?: return
+            viewModelScope.launch {
+                tripRepository.updateSegmentZoomRects(
+                    tripId = id,
+                    segmentId = segment.id,
+                    startRect = state.startRect,
+                    endRect = state.endRect,
+                )
+            }
+        }
+
+        private fun defaultEndRect(index: Int): ZoomRect {
+            val presets = listOf(
+                ZoomRect(0.15f, 0.1f, 0.85f, 0.9f),
+                ZoomRect(0.05f, 0.05f, 0.65f, 0.95f),
+                ZoomRect(0.35f, 0.05f, 0.95f, 0.95f),
+                ZoomRect(0.1f, 0.15f, 0.9f, 0.85f),
+            )
+            return presets[index % presets.size]
+        }
+    }

--- a/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
@@ -134,6 +134,7 @@ fun TimelineScreen(
                 TimelineContent(
                     uiState = uiState,
                     onRemoveSegment = { viewModel.removeSegment(it) },
+                    onNavigateToPhotoReview = onNavigateToPhotoReview,
                     modifier =
                         Modifier
                             .fillMaxSize()
@@ -148,6 +149,7 @@ fun TimelineScreen(
 private fun TimelineContent(
     uiState: TimelineUiState,
     onRemoveSegment: (TripSegment) -> Unit,
+    onNavigateToPhotoReview: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(

--- a/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
@@ -84,8 +84,8 @@ fun TimelineScreen(
     tripId: String?,
     onNavigateBack: () -> Unit,
     onNavigateToStyle: () -> Unit,
-    onNavigateToPhotoReview: (segmentId: String) -> Unit = {},
     modifier: Modifier = Modifier,
+    onNavigateToPhotoReview: (segmentId: String) -> Unit = {},
     viewModel: TimelineViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()

--- a/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
@@ -168,11 +168,12 @@ private fun TimelineContent(
                     index = index,
                     locationName = uiState.segmentLocations[segment.id],
                     onRemove = { onRemoveSegment(segment) },
-                    onPhotoClick = if (segment.type == SegmentType.PHOTO) {
-                        { onNavigateToPhotoReview(segment.id) }
-                    } else {
-                        null
-                    },
+                    onPhotoClick =
+                        if (segment.type == SegmentType.PHOTO) {
+                            { onNavigateToPhotoReview(segment.id) }
+                        } else {
+                            null
+                        },
                 )
             }
         } else {
@@ -193,11 +194,12 @@ private fun TimelineContent(
                         index = segmentIndex,
                         locationName = uiState.segmentLocations[segment.id],
                         onRemove = { onRemoveSegment(segment) },
-                        onPhotoClick = if (segment.type == SegmentType.PHOTO) {
-                            { onNavigateToPhotoReview(segment.id) }
-                        } else {
-                            null
-                        },
+                        onPhotoClick =
+                            if (segment.type == SegmentType.PHOTO) {
+                                { onNavigateToPhotoReview(segment.id) }
+                            } else {
+                                null
+                            },
                     )
                 }
             }
@@ -256,9 +258,10 @@ private fun TimelineItem(
     onPhotoClick: (() -> Unit)? = null,
 ) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .then(if (onPhotoClick != null) Modifier.clickable(onClick = onPhotoClick) else Modifier),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .then(if (onPhotoClick != null) Modifier.clickable(onClick = onPhotoClick) else Modifier),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/timeline/TimelineScreen.kt
@@ -84,6 +84,7 @@ fun TimelineScreen(
     tripId: String?,
     onNavigateBack: () -> Unit,
     onNavigateToStyle: () -> Unit,
+    onNavigateToPhotoReview: (segmentId: String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: TimelineViewModel = hiltViewModel(),
 ) {
@@ -165,6 +166,11 @@ private fun TimelineContent(
                     index = index,
                     locationName = uiState.segmentLocations[segment.id],
                     onRemove = { onRemoveSegment(segment) },
+                    onPhotoClick = if (segment.type == SegmentType.PHOTO) {
+                        { onNavigateToPhotoReview(segment.id) }
+                    } else {
+                        null
+                    },
                 )
             }
         } else {
@@ -185,6 +191,11 @@ private fun TimelineContent(
                         index = segmentIndex,
                         locationName = uiState.segmentLocations[segment.id],
                         onRemove = { onRemoveSegment(segment) },
+                        onPhotoClick = if (segment.type == SegmentType.PHOTO) {
+                            { onNavigateToPhotoReview(segment.id) }
+                        } else {
+                            null
+                        },
                     )
                 }
             }
@@ -240,9 +251,12 @@ private fun TimelineItem(
     index: Int,
     locationName: String?,
     onRemove: () -> Unit,
+    onPhotoClick: (() -> Unit)? = null,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (onPhotoClick != null) Modifier.clickable(onClick = onPhotoClick) else Modifier),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant,


### PR DESCRIPTION
## Summary

Implements Layers 1 & 2 of #88. Layer 3 (zoom rectangle review UI) is a separate follow-up.

### Layer 1 — Data model
- `ZoomRect(left, top, right, bottom)` data class (normalized 0–1 coords for Ken Burns end frame)
- `TripSegment` gains `photoAspectRatio: Float?`, `zoomRect: ZoomRect?`, `isReviewed: Boolean`
- `photoAspectRatio` populated at ingest from EXIF `width`/`height` in `ClusteringAlgorithm`

### Layer 2 — Rendering
| Condition | Effect |
|-----------|--------|
| `zoomRect` set | `kenBurnsZoomToRect` — full photo → rect; duration scales with rect area (capped 12 s) |
| Landscape photo, no rect | `kenBurnsPanHorizontal` — scales to fill height, pans left↔right alternating |
| Portrait photo, no rect | `kenBurnsZoom` — existing diagonal pan/zoom (unchanged) |

### Layer 3 (follow-up)
- `PhotoReviewScreen` — draggable/resizable rect overlay, prev/next navigation, filter toggle
- `PhotoReviewViewModel` — auto-save, review status tracking

Closes #88 (partial — rendering complete, review UI pending)

## Test plan
- [ ] CI passes
- [ ] Landscape photo renders with horizontal pan (no black bars)
- [ ] Portrait photo renders with existing diagonal Ken Burns
- [ ] `photoAspectRatio` populated correctly (check logcat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)