### PR TITLE
feat: background cover music for trip videos (#108)

### DIFF
--- a/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
+++ b/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
@@ -91,9 +91,19 @@ class TripRepository(
         template: TemplatePreset,
         aspectRatio: AspectRatio,
         transitionOverride: TransitionType?,
+        musicUri: Uri?,
+        musicVolumeDb: Float,
     ) {
         val trip = getTripById(tripId) ?: return
-        saveTrip(trip.copy(template = template, aspectRatio = aspectRatio, transitionOverride = transitionOverride))
+        saveTrip(
+            trip.copy(
+                template = template,
+                aspectRatio = aspectRatio,
+                transitionOverride = transitionOverride,
+                musicUri = musicUri,
+                musicVolumeDb = musicVolumeDb,
+            ),
+        )
     }
 
     suspend fun updateSegmentZoomRects(

--- a/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
+++ b/app/src/main/java/com/routesnap/app/data/repository/TripRepository.kt
@@ -86,22 +86,26 @@ class TripRepository(
         }
     }
 
+    data class TripStyle(
+        val template: TemplatePreset,
+        val aspectRatio: AspectRatio,
+        val transitionOverride: TransitionType?,
+        val musicUri: Uri?,
+        val musicVolumeDb: Float,
+    )
+
     suspend fun updateTripStyle(
         tripId: String,
-        template: TemplatePreset,
-        aspectRatio: AspectRatio,
-        transitionOverride: TransitionType?,
-        musicUri: Uri?,
-        musicVolumeDb: Float,
+        style: TripStyle,
     ) {
         val trip = getTripById(tripId) ?: return
         saveTrip(
             trip.copy(
-                template = template,
-                aspectRatio = aspectRatio,
-                transitionOverride = transitionOverride,
-                musicUri = musicUri,
-                musicVolumeDb = musicVolumeDb,
+                template = style.template,
+                aspectRatio = style.aspectRatio,
+                transitionOverride = style.transitionOverride,
+                musicUri = style.musicUri,
+                musicVolumeDb = style.musicVolumeDb,
             ),
         )
     }

--- a/app/src/main/java/com/routesnap/app/domain/model/Models.kt
+++ b/app/src/main/java/com/routesnap/app/domain/model/Models.kt
@@ -181,6 +181,7 @@ data class TripManifest(
     val template: TemplatePreset = TemplatePreset.BALANCED,
     val transitionOverride: TransitionType? = null,
     val musicUri: Uri? = null,
+    val musicVolumeDb: Float = 0f,
     val status: RenderStatus = RenderStatus.DRAFT,
     val outputPath: String? = null,
 ) {

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -171,10 +171,29 @@ class RenderManager
                         }
                     }
                 }
-            val sequence = EditedMediaItemSequence(editedMediaItems)
+            val mainSequence = EditedMediaItemSequence(editedMediaItems)
+            val sequences =
+                if (trip.musicUri != null) {
+                    listOf(mainSequence, buildMusicSequence(trip.musicUri))
+                } else {
+                    listOf(mainSequence)
+                }
             return Composition
-                .Builder(listOf(sequence))
+                .Builder(sequences)
                 .build()
+        }
+
+        /**
+         * Builds a looping audio-only sequence for background music.
+         * Media3 stops the music automatically when the main (first) sequence ends.
+         */
+        private fun buildMusicSequence(musicUri: android.net.Uri): EditedMediaItemSequence {
+            val musicItem =
+                EditedMediaItem
+                    .Builder(MediaItem.fromUri(musicUri))
+                    .setRemoveVideo(true)
+                    .build()
+            return EditedMediaItemSequence(listOf(musicItem), /* isLooping= */ true)
         }
 
         private fun buildPhotoSegment(

--- a/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
+++ b/app/src/main/java/com/routesnap/app/rendering/service/RenderManager.kt
@@ -193,7 +193,7 @@ class RenderManager
                     .Builder(MediaItem.fromUri(musicUri))
                     .setRemoveVideo(true)
                     .build()
-            return EditedMediaItemSequence(listOf(musicItem), /* isLooping= */ true)
+            return EditedMediaItemSequence(listOf(musicItem), true)
         }
 
         private fun buildPhotoSegment(

--- a/app/src/main/java/com/routesnap/app/ui/style/StyleScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/style/StyleScreen.kt
@@ -86,7 +86,8 @@ fun StyleScreen(
             if (uri != null) {
                 context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 val displayName =
-                    context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                    context.contentResolver
+                        .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
                         ?.use { cursor ->
                             if (cursor.moveToFirst()) cursor.getString(0) else null
                         } ?: uri.lastPathSegment ?: "Music"

--- a/app/src/main/java/com/routesnap/app/ui/style/StyleScreen.kt
+++ b/app/src/main/java/com/routesnap/app/ui/style/StyleScreen.kt
@@ -1,5 +1,10 @@
 package com.routesnap.app.ui.style
 
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,15 +16,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Crop
-import androidx.compose.material.icons.filled.FlashOn
 import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
@@ -41,6 +44,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -56,10 +60,12 @@ data class StyleUiState(
     val selectedAspectRatio: AspectRatio = AspectRatio.PORTRAIT,
     val selectedTemplate: TemplatePreset = TemplatePreset.BALANCED,
     val selectedTransition: TransitionType? = null,
-    val musicSelected: Boolean = false,
+    val musicUri: android.net.Uri? = null,
     val musicTitle: String? = null,
     val isProcessing: Boolean = false,
-)
+) {
+    val musicSelected: Boolean get() = musicUri != null
+}
 
 /**
  * Style Screen - Select aspect ratio, template, and music
@@ -73,6 +79,20 @@ fun StyleScreen(
     viewModel: StyleViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    val musicPickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri != null) {
+                context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                val displayName =
+                    context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                        ?.use { cursor ->
+                            if (cursor.moveToFirst()) cursor.getString(0) else null
+                        } ?: uri.lastPathSegment ?: "Music"
+                viewModel.setMusicUri(uri, displayName)
+            }
+        }
 
     RouteSnapTheme {
         Scaffold(
@@ -144,7 +164,8 @@ fun StyleScreen(
                     MusicSelector(
                         musicSelected = uiState.musicSelected,
                         musicTitle = uiState.musicTitle,
-                        onMusicSelect = { viewModel.selectMusic() },
+                        onMusicSelect = { musicPickerLauncher.launch(arrayOf("audio/*")) },
+                        onMusicRemove = { viewModel.removeMusic() },
                     )
                 }
 
@@ -380,6 +401,7 @@ private fun MusicSelector(
     musicSelected: Boolean,
     musicTitle: String?,
     onMusicSelect: () -> Unit,
+    onMusicRemove: () -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -393,11 +415,12 @@ private fun MusicSelector(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(start = 16.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Row(
+                modifier = Modifier.weight(1f),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
@@ -411,28 +434,23 @@ private fun MusicSelector(
                         text = if (musicSelected) musicTitle ?: "Music Selected" else "Select Music",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,
+                        maxLines = 1,
                     )
-                    if (musicSelected) {
-                        Text(
-                            text = "Tap to change",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    } else {
-                        Text(
-                            text = "Add background music to your video",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
+                    Text(
+                        text = if (musicSelected) "Tap to change" else "Add background music to your video",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
             if (musicSelected) {
-                Icon(
-                    imageVector = Icons.Default.CheckCircle,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
+                IconButton(onClick = onMusicRemove) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Remove music",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/routesnap/app/ui/style/StyleViewModel.kt
+++ b/app/src/main/java/com/routesnap/app/ui/style/StyleViewModel.kt
@@ -77,11 +77,13 @@ class StyleViewModel
             viewModelScope.launch {
                 tripRepository.updateTripStyle(
                     id,
-                    _uiState.value.selectedTemplate,
-                    _uiState.value.selectedAspectRatio,
-                    _uiState.value.selectedTransition,
-                    _uiState.value.musicUri,
-                    0f,
+                    TripRepository.TripStyle(
+                        template = _uiState.value.selectedTemplate,
+                        aspectRatio = _uiState.value.selectedAspectRatio,
+                        transitionOverride = _uiState.value.selectedTransition,
+                        musicUri = _uiState.value.musicUri,
+                        musicVolumeDb = 0f,
+                    ),
                 )
                 onReady()
             }

--- a/app/src/main/java/com/routesnap/app/ui/style/StyleViewModel.kt
+++ b/app/src/main/java/com/routesnap/app/ui/style/StyleViewModel.kt
@@ -1,5 +1,6 @@
 package com.routesnap.app.ui.style
 
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -26,6 +27,24 @@ class StyleViewModel
         private val _uiState = MutableStateFlow(StyleUiState())
         val uiState: StateFlow<StyleUiState> = _uiState.asStateFlow()
 
+        init {
+            if (tripId != null) loadExistingStyle(tripId)
+        }
+
+        private fun loadExistingStyle(id: String) {
+            viewModelScope.launch {
+                val trip = tripRepository.getTripById(id) ?: return@launch
+                _uiState.value =
+                    StyleUiState(
+                        selectedAspectRatio = trip.aspectRatio,
+                        selectedTemplate = trip.template,
+                        selectedTransition = trip.transitionOverride,
+                        musicUri = trip.musicUri,
+                        musicTitle = trip.musicUri?.lastPathSegment?.substringAfterLast('/'),
+                    )
+            }
+        }
+
         fun updateAspectRatio(aspectRatio: AspectRatio) {
             _uiState.value = _uiState.value.copy(selectedAspectRatio = aspectRatio)
         }
@@ -38,12 +57,15 @@ class StyleViewModel
             _uiState.value = _uiState.value.copy(selectedTransition = transition)
         }
 
-        fun selectMusic() {
-            _uiState.value =
-                _uiState.value.copy(
-                    musicSelected = !_uiState.value.musicSelected,
-                    musicTitle = if (!_uiState.value.musicSelected) "Default Track" else null,
-                )
+        fun setMusicUri(
+            uri: Uri,
+            displayName: String,
+        ) {
+            _uiState.value = _uiState.value.copy(musicUri = uri, musicTitle = displayName)
+        }
+
+        fun removeMusic() {
+            _uiState.value = _uiState.value.copy(musicUri = null, musicTitle = null)
         }
 
         fun saveAndRender(onReady: () -> Unit) {
@@ -58,6 +80,8 @@ class StyleViewModel
                     _uiState.value.selectedTemplate,
                     _uiState.value.selectedAspectRatio,
                     _uiState.value.selectedTransition,
+                    _uiState.value.musicUri,
+                    0f,
                 )
                 onReady()
             }


### PR DESCRIPTION
## Summary
- Music picker on Style screen via `ACTION_OPEN_DOCUMENT` (audio/*); takes persistable URI permission and shows track filename
- Remove (×) button clears the selected track
- `StyleViewModel` loads existing trip music on init; `setMusicUri` / `removeMusic` replace the old stub
- `TripRepository.updateTripStyle` persists `musicUri` + `musicVolumeDb` into the manifest
- `RenderManager` adds a looping `EditedMediaItemSequence` (audio-only, `setRemoveVideo=true`) when `musicUri` is present; Media3 Transformer automatically trims/stops the music when the main video sequence ends

## Test plan
- [ ] Open a trip → Style screen → tap Music card → system audio picker opens
- [ ] Pick an MP3/AAC file → card shows filename + × button
- [ ] Tap × → card resets to "Select Music"
- [ ] Tap render → trip manifest persists music URI
- [ ] Rendered video plays background music throughout
- [ ] No music selected → render output unchanged (no regression)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)